### PR TITLE
Fix backslashes not being escaped on configure win-e documentation

### DIFF
--- a/src/routes/docs/configuring/configure-win-e.svx
+++ b/src/routes/docs/configuring/configure-win-e.svx
@@ -9,7 +9,7 @@ script:
 ; Win + E
 #e::
 FilesTitle := "Files ahk_class ApplicationFrameWindow ahk_exe ApplicationFrameHost.exe"
-FilesLocation := USERPROFILE . "\AppData\Local\Microsoft\WindowsApps\files.exe"
+FilesLocation := USERPROFILE . "\\AppData\\Local\\Microsoft\\WindowsApps\\files.exe"
     if WinExist(FilesTitle) {
         WinActivate % FilesTitle     ; Set focus
         SendInput ^t                    ; Send CTRL + t shortcut to open a new tab


### PR DESCRIPTION
The backslashes were not properly escaped in the sample resulting in them not being rendered. Fixes #23 