### PR TITLE
Added switch to previous tab shortcut

### DIFF
--- a/src/routes/docs/configuring/keyboard-shortcuts.svx
+++ b/src/routes/docs/configuring/keyboard-shortcuts.svx
@@ -14,7 +14,8 @@ Files comes with built in keyboard shortcuts to make naviagting the app easier.
 | `Ctrl` + `W` | Close tab |
 | `Ctrl` + `F4` | Close tab |
 | `Ctrl` + `Shift` + `T` | Reopen recently closed tab |
-| `Ctrl` + `Tab` | Switch tab |
+| `Ctrl` + `Tab` | Switch next tab |
+| `Ctrl` + `Shift` + `Tab` | Switch previous tab |
 | `Ctrl` + `N` | New window |
 | `Ctrl` + `Shift` + `N` | New file |
 | `Ctrl` + `Alt` + `Up` | Open compact overlay |


### PR DESCRIPTION
## Description
Also modified the next tab to keep logical both shortcuts.

I am not sure if it would be more appropiate "switch to next tab" and "switch to previous tab" instead this commit, opinions are welcome.

## Motivation and Context
<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->
Some people doesn't know this shortcut exists (https://github.com/files-community/Files/issues/6557)

## Screenshots (if appropriate):
<!-- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
I didn't tested it, if it's necessary even with this little addition I can read the instructions and do it.