### PR TITLE
Create new style for `<kbd>` tags in the docs.

### DIFF
--- a/src/routes/docs/configuring/keyboard-shortcuts.svx
+++ b/src/routes/docs/configuring/keyboard-shortcuts.svx
@@ -2,35 +2,35 @@
 
 Files comes with built in keyboard shortcuts to make navigating the app easier.
 
-| Shortcut | Action |
-| :---: | :---: |
-| `Ctrl` + `C` | Copy |
-| `Ctrl` + `X` | Cut |
-| `Ctrl` + `V` | Paste |
-| `Ctrl` + `A` | Select all |
-| `Ctrl` + `Z` | Undo operation |
-| `Ctrl` + `Y` | Redo operation |
-| `Ctrl` + `T` | Create new tab |
-| `Ctrl` + `W` | Close tab |
-| `Ctrl` + `F4` | Close tab |
-| `Ctrl` + `Shift` + `T` | Reopen recently closed tab |
-| `Ctrl` + `Tab` | Switch next tab |
-| `Ctrl` + `Shift` + `Tab` | Switch previous tab |
-| `Ctrl` + `N` | New window |
-| `Ctrl` + `Shift` + `N` | New file |
-| `Ctrl` + `Alt` + `Up` | Open compact overlay |
-| `Ctrl` + `Alt` + `Down` | Close compact overlay |
-| `Ctrl` + `+` | Increase icon size |
-| `Ctrl` + `-` | Decrease icon size |
-| `Ctrl` + `D` | Delete |
-| `Ctrl` + `F` | Search |
-| `Ctrl` + `L` | Select directory path |
-| `Ctrl` + `Shift` + `C` | Copy file/directory path |
-| `Ctrl` + `P` | Toggle preview pane |
-| `F1` | Open files docs |
-| `F2` | Rename file/directory |
-| `F3` | Search |
-| `F5` / `Ctrl` + `R` | Refresh directory |
-| `F7` | Turn on caret browsing |
-| `F11` | Toggle fullscreen |
-| `F12` | Toggle compact overlay |
+|                      Shortcut                       |           Action           |
+|:---------------------------------------------------:|:--------------------------:|
+|           <kbd>Ctrl</kbd> + <kbd>C</kbd>            |            Copy            |
+|           <kbd>Ctrl</kbd> + <kbd>X</kbd>            |            Cut             |
+|           <kbd>Ctrl</kbd> + <kbd>V</kbd>            |           Paste            |
+|           <kbd>Ctrl</kbd> + <kbd>A</kbd>            |         Select all         |
+|           <kbd>Ctrl</kbd> + <kbd>Z</kbd>            |       Undo operation       |
+|           <kbd>Ctrl</kbd> + <kbd>Y</kbd>            |       Redo operation       |
+|           <kbd>Ctrl</kbd> + <kbd>T</kbd>            |       Create new tab       |
+|           <kbd>Ctrl</kbd> + <kbd>W</kbd>            |         Close tab          |
+|           <kbd>Ctrl</kbd> + <kbd>F4</kbd>           |         Close tab          |
+|  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>T</kbd>  | Reopen recently closed tab |
+|          <kbd>Ctrl</kbd> + <kbd>Tab</kbd>           |      Switch next tab       |
+| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd> |    Switch previous tab     |
+|           <kbd>Ctrl</kbd> + <kbd>N</kbd>            |         New window         |
+|  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>N</kbd>  |          New file          |
+|  <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Up</kbd>   |    Open compact overlay    |
+| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Down</kbd>  |   Close compact overlay    |
+|           <kbd>Ctrl</kbd> + <kbd>+</kbd>            |     Increase icon size     |
+|           <kbd>Ctrl</kbd> + <kbd>-</kbd>            |     Decrease icon size     |
+|           <kbd>Ctrl</kbd> + <kbd>D</kbd>            |           Delete           |
+|           <kbd>Ctrl</kbd> + <kbd>F</kbd>            |           Search           |
+|           <kbd>Ctrl</kbd> + <kbd>L</kbd>            |   Select directory path    |
+|  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>  |  Copy file/directory path  |
+|           <kbd>Ctrl</kbd> + <kbd>P</kbd>            |    Toggle preview pane     |
+|                    <kbd>F1</kbd>                    |      Open files docs       |
+|                    <kbd>F2</kbd>                    |   Rename file/directory    |
+|                    <kbd>F3</kbd>                    |           Search           |
+|   <kbd>F5</kbd> / <kbd>Ctrl</kbd> + <kbd>R</kbd>    |     Refresh directory      |
+|                    <kbd>F7</kbd>                    |   Turn on caret browsing   |
+|                   <kbd>F11</kbd>                    |     Toggle fullscreen      |
+|                   <kbd>F12</kbd>                    |   Toggle compact overlay   |

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -140,6 +140,16 @@
 		font-size: 85%;
 	}
 
+	kbd {
+		padding: 0.3em 0.4em;
+		color: hsl(70, 5%, 22%);
+		box-shadow: inset 0 -.2em 0 var(--subtle-color-tertiary);
+
+		@media (prefers-color-scheme: dark) {
+			color: hsl(0, 0%, 83%);
+		}
+	}
+
 	pre {
 		padding: 12px 16px;
 		border: 1px solid var(--card-stroke-default);


### PR DESCRIPTION
## Description
Adds a new style for `<kbd>` tags (i. e. <kbd>Ctrl</kbd>) in markdown (docs & blog posts).

## Motivation and Context
Just seems nice to have, instead of it looking identical to inline code snippets.

## Screenshots (if appropriate):
![A screenshot of the new style for `<kbd>` tags](https://user-images.githubusercontent.com/65342367/140623309-38beeef1-5b13-4580-8a7f-d85b35353fa7.png)