### PR TITLE
Fixed all typescript errors (as indicated by svelte-check)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,7 +329,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.3.0
-      eslint-visitor-keys: 3.0.0
+      eslint-visitor-keys: 3.1.0
     dev: true
 
   /acorn-jsx/5.3.2_acorn@8.5.0:
@@ -982,8 +982,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-visitor-keys/3.0.0:
-    resolution: {integrity: sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==}
+  /eslint-visitor-keys/3.1.0:
+    resolution: {integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -1003,7 +1003,7 @@ packages:
       escape-string-regexp: 4.0.0
       eslint-scope: 6.0.0
       eslint-utils: 3.0.0_eslint@8.2.0
-      eslint-visitor-keys: 3.0.0
+      eslint-visitor-keys: 3.1.0
       espree: 9.0.0
       esquery: 1.4.0
       esutils: 2.0.3
@@ -1040,7 +1040,7 @@ packages:
     dependencies:
       acorn: 8.5.0
       acorn-jsx: 5.3.2_acorn@8.5.0
-      eslint-visitor-keys: 3.0.0
+      eslint-visitor-keys: 3.1.0
     dev: true
 
   /esquery/1.4.0:

--- a/src/data/fetchHomepageData.ts
+++ b/src/data/fetchHomepageData.ts
@@ -32,10 +32,8 @@ export const getReleaseUrl = async () =>
 		.then(result => result.json())
 
 		// Find the first asset in the release that has a file extension of "msixbundle" and return it's download link
-		.then(
-			result =>
-				result.assets.find(a => a.name.endsWith(".zip"))
-					.browser_download_url
+		.then(result =>
+			result.assets.find((a: { name: string }) => a.name.endsWith(".zip"))?.browser_download_url
 		)
 
 		// Error handler

--- a/src/layout/CommunitySection/CommunitySection.svelte
+++ b/src/layout/CommunitySection/CommunitySection.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { ContributorData } from "$data/fetchHomepageData";
 	import { getContributors } from "$data/fetchHomepageData";
-
 	import { onMount } from "svelte";
 
 	import { links } from "$data/links";
@@ -16,9 +15,6 @@
 	// Fetch contributors for the community section
 	let [contributors1, contributors2, contributors3]: Array<ContributorData[]> =
 		[[], [], []];
-
-	// Utility function for randomly shuffling an array
-	const shuffle = a => a.sort(() => Math.random() - 0.5);
 
 	onMount(async () => {
 		// Fetch contributors for the community section
@@ -38,11 +34,11 @@
 				collective of hundreds of contributors.
 			</p>
 			<div class="buttons-spacer">
-				<HyperlinkButton href="https://discord.gg/{links.discord}"
-					>Join the discussion
+				<HyperlinkButton href="https://discord.gg/{links.discord}">
+					Join the discussion
 				</HyperlinkButton>
-				<HyperlinkButton href="/docs/contributing/code-style"
-					>Become a contributor
+				<HyperlinkButton href="/docs/contributing/code-style">
+					Become a contributor
 				</HyperlinkButton>
 			</div>
 		</div>
@@ -50,7 +46,7 @@
 			<div class="contributors-container">
 				{#each [contributors1, contributors2, contributors3] as contributors}
 					<div class="contributors-row">
-						{#each shuffle(contributors) as { html_url, avatar_url, login, contributions, type }}
+						{#each contributors.sort(() => Math.random() - 0.5) as { html_url, avatar_url, login, contributions, type }}
 							<Contributor
 								{html_url}
 								{avatar_url}
@@ -63,7 +59,7 @@
 				{/each}
 			</div>
 		{/if}
-		<canvas use:rainbowCanvas />
+		<canvas use:rainbowCanvas></canvas>
 	</div>
 </PageSection>
 

--- a/src/layout/FeaturesSection/FeatureShowcase.svelte
+++ b/src/layout/FeaturesSection/FeatureShowcase.svelte
@@ -269,7 +269,7 @@
 			<div class="showcase-panel">
 				<Titlebar>Files</Titlebar>
 				<div class="files-grid">
-					{#each Array(12) as file, i}
+					{#each Array(12) as _, i}
 						<div style="--file-index: {i};" class="placeholder-file"></div>
 					{/each}
 				</div>

--- a/src/layout/HeroSection/HeroSection.svelte
+++ b/src/layout/HeroSection/HeroSection.svelte
@@ -16,6 +16,7 @@
 	import Code from "@fluentui/svg-icons/icons/code_24_regular.svg?raw";
 
 	type DownloadOptions = "Microsoft Store" | "GitHub Release" | "Winget (CLI)";
+	const downloadOptions: DownloadOptions[] = ["Microsoft Store", "GitHub Release", "Winget (CLI)"]
 
 	// Check the user agent for a windows install
 	let isWindows: boolean;
@@ -45,10 +46,7 @@
 	const updateDownloadSource = (value: number) =>
 		localStorage.setItem("downloadSource", value.toString());
 
-	const changeDownloadSource = (
-		downloadOption: DownloadOptions,
-		id: number
-	) => {
+	const changeDownloadSource = (downloadOption: DownloadOptions, id: number) => {
 		updateDownloadSource(id);
 
 		switch (downloadOption) {
@@ -111,7 +109,7 @@
 						{@html ChevronDown}
 					</Button>
 					<svelte:fragment slot="menu">
-						{#each ["Microsoft Store", "GitHub Release", "Winget (CLI)"] as downloadOption, id}
+						{#each downloadOptions as downloadOption, id}
 							<ListViewItem
 								bind:group={currentDownloadSource}
 								on:change={() => changeDownloadSource(downloadOption, id)}

--- a/src/layout/Navbar/Navbar.svelte
+++ b/src/layout/Navbar/Navbar.svelte
@@ -10,24 +10,26 @@
 
 	let innerWidth = 649; // Don't render the mobile layout before hydration
 	let sidebarVisible = false;
-	let sidebar;
+	let sidebar: HTMLElement;
 	let sidebarButton: HTMLButtonElement;
 
-	function toggleSidebar() {
+	const toggleSidebar = () => {
 		sidebarVisible = !sidebarVisible;
-	}
+	};
 
-	function handleOuterClick(e) {
+	const handleOuterClick = (e: MouseEvent) => {
 		if (
 			!sidebarVisible ||
 			e.target === sidebarButton ||
-			sidebarButton.contains(e.target) ||
+			sidebarButton.contains(e.target as Node) ||
 			e.target === sidebar ||
-			sidebar.contains(e.target)
-		)
+			sidebar.contains(e.target as Node)
+		) {
 			return;
-		toggleSidebar();
-	}
+		} else {
+			toggleSidebar();
+		}
+	};
 </script>
 
 <svelte:window bind:innerWidth on:click={handleOuterClick} />

--- a/src/layout/ThemesSection/ThemesSection.svelte
+++ b/src/layout/ThemesSection/ThemesSection.svelte
@@ -15,7 +15,6 @@
 	let visible = true;
 	let noInitialDelay = false;
 	let anchor: HTMLDivElement;
-	let showcase: HTMLDivElement;
 
 	const themeColors = [
 		"var(--background-tertiary);",
@@ -101,7 +100,6 @@
 		</div>
 	</div>
 	<div
-		bind:this={showcase}
 		class="component-showcase"
 		class:no-initial-delay={noInitialDelay}
 		class:visible

--- a/src/lib/MenuFlyout/MenuFlyoutWrapper.svelte
+++ b/src/lib/MenuFlyout/MenuFlyoutWrapper.svelte
@@ -8,8 +8,8 @@
 	// $: if (open) toggleDropdown();
 
 	let container: HTMLDivElement;
-	const handleOuterClick = e => {
-		if (open && ((!e.target && container) || !container.contains(e.target)))
+	const handleOuterClick = (e: MouseEvent) => {
+		if (open && ((!e.target && container) || !container.contains(e.target as Node)))
 			toggleDropdown();
 	};
 </script>

--- a/src/lib/TreeView/TreeView.svelte
+++ b/src/lib/TreeView/TreeView.svelte
@@ -6,7 +6,7 @@
 
 	export let tree = [];
 
-	let treeViewState;
+	let treeViewState: any;
 
 	onMount(() => {
 		// Check localStorage for an existing treeViewState
@@ -15,10 +15,10 @@
 	});
 
 	// Utility function for converting regular names to kebab case
-	const id = s => s.toLowerCase().split(" ").join("-");
+	const id = (s: string) => s.toLowerCase().split(" ").join("-");
 
 	// Function for expanding/collapsing docs categories
-	const toggleExpansion = (event: MouseEvent, name) => {
+	const toggleExpansion = (event: MouseEvent, name: string) => {
 		event.stopPropagation();
 
 		// Modify treeViewState to have the opposite of the previous entry for the category

--- a/src/lib/tilt.ts
+++ b/src/lib/tilt.ts
@@ -1,15 +1,19 @@
-function getSettings(settings = {}) {
-	return { scale: 1, max: 15, reverse: false, ...settings };
+interface TiltSettings {
+	scale?: number,
+	max?: number,
+	reverse?: false,
 }
+
+const getSettings = (settings: TiltSettings = {}) => ({ scale: 1, max: 15, reverse: false, ...settings });
 
 const TRANSITION_MS = 300;
 
-export default function tilt(node, settingsObj) {
+export default function tilt(node: HTMLElement, settingsObj: TiltSettings) {
 	const { width, height, left, top } = node.getBoundingClientRect();
 	let settings = getSettings(settingsObj);
 	let reverse = settings.reverse ? -1 : 1;
 
-	function onMouseMove(e) {
+	function onMouseMove(e: MouseEvent) {
 		const percX = (e.clientX - left) / width;
 		const percY = (e.clientY - top) / height;
 
@@ -25,7 +29,7 @@ export default function tilt(node, settingsObj) {
 			`scale3d(${Array(3).fill(scale).join(", ")})`;
 	}
 
-	let transitionId;
+	let transitionId: NodeJS.Timeout;
 
 	function smoothTransition() {
 		clearTimeout(transitionId);
@@ -61,7 +65,8 @@ export default function tilt(node, settingsObj) {
 			node.removeEventListener("mouseleave", onMouseLeave);
 			node.removeEventListener("mouseleave", onMouseEnter);
 		},
-		update(settingsObj) {
+
+		update(settingsObj: TiltSettings) {
 			settings = getSettings(settingsObj);
 			reverse = settings.reverse ? -1 : 1;
 		}

--- a/src/routes/blog/posts/[slug].json.ts
+++ b/src/routes/blog/posts/[slug].json.ts
@@ -1,11 +1,13 @@
 import type { RequestHandler } from "@sveltejs/kit";
 
-const slugFromPath = path => path.match(/([\w-]+)\.(md|svx)/i)?.[1] ?? null;
+const slugFromPath = (path: string) => path.match(/([\w-]+)\.(md|svx)/i)?.[1] ?? null;
 
 export const get: RequestHandler = async ({ params }) => {
 	const modules = import.meta.glob("./*.svx");
 
-	let match;
+	type Resolver = () => Promise<{[p: string]: any}>
+
+	let match: [string, Resolver];
 	for (const [path, resolver] of Object.entries(modules)) {
 		if (slugFromPath(path) === params.slug) {
 			match = [path, resolver];

--- a/src/routes/blog/posts/__layout.svelte
+++ b/src/routes/blog/posts/__layout.svelte
@@ -14,7 +14,15 @@
 	import Share from "@fluentui/svg-icons/icons/share_24_regular.svg?raw";
 	import ArrowLeft from "@fluentui/svg-icons/icons/arrow_left_24_regular.svg?raw";
 
-	export let post;
+	export let post: {
+		metadata: {
+			title: string;
+			description: string;
+			thumbnail: string;
+			date: string;
+			author: string;
+		}
+	};
 
 	const { title, thumbnail, author, date } = post.metadata;
 </script>

--- a/src/routes/docs/__layout.svelte
+++ b/src/routes/docs/__layout.svelte
@@ -2,7 +2,7 @@
 	import { goto } from "$app/navigation";
 	import { page } from "$app/stores";
 
-	import { docs } from "$data/docs";
+	import { docs, DocsMap } from "$data/docs";
 	import { links } from "$data/links";
 
 	import { HyperlinkButton, ListViewItem, TextBox, TreeView } from "$lib";
@@ -14,7 +14,7 @@
 	let selection: number = 0;
 
 	// A recursively flattened version of the docs mapping containing an array of all pages
-	const docsPages = filterPages(docs);
+	const docsPages: DocsMap[] = filterPages(docs);
 
 	// These are pretty self-explanatory
 	$: currentPage = docsPages.find(p => `/docs${ p.path }` === $page.path);
@@ -58,8 +58,8 @@
 	};
 
 	// Action for handling clicks outside of a DOM node
-	const clickOutside = (node, eventHandler) => {
-		const handleClick = event => {
+	const clickOutside = (node: Element, eventHandler: () => boolean) => {
+		const handleClick = (event: MouseEvent) => {
 			const path = event.composedPath();
 			if (!path.includes(node)) eventHandler();
 		};

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -6,7 +6,7 @@
 		HeroSection,
 		ThemesSection,
 		Footer
-	} from "$layout/";
+	} from "$layout";
 	import { page } from "$app/stores";
 </script>
 

--- a/src/styles/pages/blog.scss
+++ b/src/styles/pages/blog.scss
@@ -44,12 +44,12 @@
 		height: auto;
 		border: 1px solid var(--surface-stroke-default);
 		border-radius: var(--overlay-corner-radius);
-		box-shadow: 0 2.74416px 2.74416px hsl(0, 0%, 0% / 3%),
-		0 5.48831px 5.48831px hsl(0, 0%, 0% / 4%),
-		0 13.7208px 10.9766px hsl(0, 0%, 0% / 5%),
-		0 20.5812px 20.5812px hsl(0, 0%, 0% / 6%),
-		0 41.1623px 41.1623px hsl(0, 0%, 0% / 7%),
-		0 96.0454px 89.1851px hsl(0, 0%, 0% / 9%);
+		box-shadow: 0 2.74416px 2.74416px hsl(0, 0%, 0%, 3%),
+		0 5.48831px 5.48831px hsl(0, 0%, 0%, 4%),
+		0 13.7208px 10.9766px hsl(0, 0%, 0%, 5%),
+		0 20.5812px 20.5812px hsl(0, 0%, 0%, 6%),
+		0 41.1623px 41.1623px hsl(0, 0%, 0%, 7%),
+		0 96.0454px 89.1851px hsl(0, 0%, 0%, 9%);
 		transition: 200ms ease !important;
 		-webkit-user-drag: none;
 		aspect-ratio: 3 / 2;


### PR DESCRIPTION
## Description
All typescript errors (as indicated by svelte-check) are now fixed, except for in `rainbowCanvas.js` and `filterPages` (in the docs layout), which we treat as black boxes.

## Motivation and Context
The code is less error prone this way.