### PR TITLE
Overhauled the `filterPages` function to include comments, types, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@fec/remark-a11y-emoji": "^3.1.0",
 		"@fluentui/svg-icons": "^1.1.150",
 		"@sveltejs/adapter-netlify": "^1.0.0-next.35",
-		"@sveltejs/kit": "^1.0.0-next.195",
+		"@sveltejs/kit": "^1.0.0-next.196",
 		"@typescript-eslint/eslint-plugin": "^5.3.1",
 		"@typescript-eslint/parser": "^5.3.1",
 		"autoprefixer": "^10.4.0",
@@ -35,7 +35,7 @@
 		"sass": "^1.43.4",
 		"svelte": "^3.44.1",
 		"svelte-check": "^2.2.8",
-		"svelte-drag": "^2.0.4",
+		"svelte-drag": "^2.2.0",
 		"svelte-preprocess": "^4.9.8",
 		"tslib": "^2.3.1",
 		"typescript": "^4.4.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ specifiers:
   '@fec/remark-a11y-emoji': ^3.1.0
   '@fluentui/svg-icons': ^1.1.150
   '@sveltejs/adapter-netlify': ^1.0.0-next.35
-  '@sveltejs/kit': ^1.0.0-next.195
+  '@sveltejs/kit': ^1.0.0-next.196
   '@typescript-eslint/eslint-plugin': ^5.3.1
   '@typescript-eslint/parser': ^5.3.1
   autoprefixer: ^10.4.0
@@ -23,7 +23,7 @@ specifiers:
   sass: ^1.43.4
   svelte: ^3.44.1
   svelte-check: ^2.2.8
-  svelte-drag: ^2.0.4
+  svelte-drag: ^2.2.0
   svelte-preprocess: ^4.9.8
   tslib: ^2.3.1
   typescript: ^4.4.4
@@ -32,7 +32,7 @@ devDependencies:
   '@fec/remark-a11y-emoji': 3.1.0
   '@fluentui/svg-icons': 1.1.150
   '@sveltejs/adapter-netlify': 1.0.0-next.35
-  '@sveltejs/kit': 1.0.0-next.195_sass@1.43.4+svelte@3.44.1
+  '@sveltejs/kit': 1.0.0-next.196_sass@1.43.4+svelte@3.44.1
   '@typescript-eslint/eslint-plugin': 5.3.1_4653b7803b7453f5f37717b7e1448517
   '@typescript-eslint/parser': 5.3.1_eslint@8.2.0+typescript@4.4.4
   autoprefixer: 10.4.0_postcss@8.3.11
@@ -51,7 +51,7 @@ devDependencies:
   sass: 1.43.4
   svelte: 3.44.1
   svelte-check: 2.2.8_210a682e3c539664016a09fdf260fd16
-  svelte-drag: 2.0.4
+  svelte-drag: 2.2.0
   svelte-preprocess: 4.9.8_0817bf3c3dfca1bb72a040b4f6836cb8
   tslib: 2.3.1
   typescript: 4.4.4
@@ -144,8 +144,8 @@ packages:
       esbuild: 0.13.13
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.195_sass@1.43.4+svelte@3.44.1:
-    resolution: {integrity: sha512-R2X4FgzXQhp63XOik6S1Flw91S2CEA7sTxdsnNFrq3O+bIN7pQhJhkm6zgH68MZANdDcq8oIiSRkxT4M3t1+jQ==}
+  /@sveltejs/kit/1.0.0-next.196_sass@1.43.4+svelte@3.44.1:
+    resolution: {integrity: sha512-z7sA/2/3Il5biibjPXCYXJC11TyFhgCvMaJvvbtMnu2l3EmOmJBMS+r2djGptzfFsugSVNwGQFn8+ldWQWq3jA==}
     engines: {node: '>=14.13'}
     hasBin: true
     peerDependencies:
@@ -401,8 +401,8 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.17.6
-      caniuse-lite: 1.0.30001279
-      fraction.js: 4.1.1
+      caniuse-lite: 1.0.30001280
+      fraction.js: 4.1.2
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss: 8.3.11
@@ -445,8 +445,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001279
-      electron-to-chromium: 1.3.895
+      caniuse-lite: 1.0.30001280
+      electron-to-chromium: 1.3.896
       escalade: 3.1.1
       node-releases: 2.0.1
       picocolors: 1.0.0
@@ -465,13 +465,13 @@ packages:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.17.6
-      caniuse-lite: 1.0.30001279
+      caniuse-lite: 1.0.30001280
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: true
 
-  /caniuse-lite/1.0.30001279:
-    resolution: {integrity: sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==}
+  /caniuse-lite/1.0.30001280:
+    resolution: {integrity: sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==}
     dev: true
 
   /ccount/2.0.1:
@@ -733,8 +733,8 @@ packages:
       domhandler: 4.2.2
     dev: true
 
-  /electron-to-chromium/1.3.895:
-    resolution: {integrity: sha512-9Ww3fB8CWctjqHwkOt7DQbMZMpal2x2reod+/lU4b9axO1XJEDUpPMBxs7YnjLhhqpKXIIB5SRYN/B4K0QpvyQ==}
+  /electron-to-chromium/1.3.896:
+    resolution: {integrity: sha512-NcGkBVXePiuUrPLV8IxP43n1EOtdg+dudVjrfVEUd/bOqpQUFZ2diL5PPYzbgEhZFEltdXV3AcyKwGnEQ5lhMA==}
     dev: true
 
   /emoji-regex/9.2.2:
@@ -1135,8 +1135,8 @@ packages:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
     dev: true
 
-  /fraction.js/4.1.1:
-    resolution: {integrity: sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==}
+  /fraction.js/4.1.2:
+    resolution: {integrity: sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==}
     dev: true
 
   /fs.realpath/1.0.0:
@@ -2304,8 +2304,8 @@ packages:
       glob: 7.2.0
     dev: true
 
-  /rollup/2.59.0:
-    resolution: {integrity: sha512-l7s90JQhCQ6JyZjKgo7Lq1dKh2RxatOM+Jr6a9F7WbS9WgKbocyUSeLmZl8evAse7y96Ae98L2k1cBOwWD8nHw==}
+  /rollup/2.60.0:
+    resolution: {integrity: sha512-cHdv9GWd58v58rdseC8e8XIaPUo8a9cgZpnCMMDGZFDZKEODOiPPEQFXLriWr/TjXzhPPmG5bkAztPsOARIcGQ==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -2466,8 +2466,8 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-drag/2.0.4:
-    resolution: {integrity: sha512-HBOVKu6FkmOXrGLzS2PFIJkjx392qQABo8ZAUt1XooU03cowisnTatypQSouiAyLleXFrLYe7E51EfaDP9Qd6w==}
+  /svelte-drag/2.2.0:
+    resolution: {integrity: sha512-FqfG28RTgan0tO8PlzEQB7O2Ut+P9aXwnSL2AD6es7b+Y67yDqH8Bi1R5J0BVwt6I7rk2dhkX01ivLxdRp1AUA==}
     dev: true
 
   /svelte-hmr/0.14.7_svelte@3.44.1:
@@ -2755,7 +2755,7 @@ packages:
       esbuild: 0.13.13
       postcss: 8.3.11
       resolve: 1.20.0
-      rollup: 2.59.0
+      rollup: 2.60.0
       sass: 1.43.4
     optionalDependencies:
       fsevents: 2.3.2

--- a/src/routes/docs/__layout.svelte
+++ b/src/routes/docs/__layout.svelte
@@ -57,7 +57,7 @@
 		}
 	};
 
-	// Action for handling clicks outside of a DOM node
+	// Action for handling clicks outside a DOM node
 	const clickOutside = (node: Element, eventHandler: () => boolean) => {
 		const handleClick = (event: MouseEvent) => {
 			const path = event.composedPath();
@@ -73,21 +73,24 @@
 		};
 	};
 
-	// ??????
-	function filterPages(array) {
-		if (Array.isArray(array))
-			return array
-				.map(a => filterPages(a))
-				.flat(Infinity)
-				.filter(a => a.hasOwnProperty("path")); // ???
-		if (array.hasOwnProperty("pages"))
-			return [
-				{
-					...array
-				},
-				...array.pages.map(a => filterPages(a))
-			]; // ?????????
-		return array;
+	function filterPages(docsStructure: DocsMap[] | DocsMap): DocsMap[] {
+		if (Array.isArray(docsStructure)) {
+			// it's an array of pages/categories
+			return docsStructure
+				.map(page => filterPages(page)) // recursively flatten the structure and filter to only include pages
+				.flat(Infinity) as DocsMap[]; // flatten the structure to get rid of any nesting
+		} else {
+			// it's a single page/category, not a structure
+			if (docsStructure.type === "category") {
+				// it's a category
+				return docsStructure.pages
+					.map(page => filterPages(page)) // filter down and down until only pages are left
+					.flat(Infinity) as DocsMap[]; // flatten the array
+			} else {
+				// it's a page
+				return [docsStructure];
+			}
+		}
 	}
 </script>
 


### PR DESCRIPTION
## Description
Overhauled the `filterPages` function to include comments, types, etc.
Updated packages.

## Motivation and Context
This comes as an improvement to the old one, which was undocumented, hard to use/understand, and was impossible to debug if it were to cause problems.

Here is the new one, in all of its glory:
```ts
function filterPages(docsStructure: DocsMap[] | DocsMap): DocsMap[] {
  if (Array.isArray(docsStructure)) {
    // it's an array of pages/categories
    return docsStructure
      .map(page => filterPages(page)) // recursively flatten the structure and filter to only include pages
      .flat(Infinity) as DocsMap[]; // flatten the structure to get rid of any nesting
  } else {
    // it's a single page/category, not a structure
    if (docsStructure.type === "category") {
      // it's a category
      return docsStructure.pages
        .map(page => filterPages(page)) // filter down and down until only pages are left
        .flat(Infinity) as DocsMap[]; // flatten the array
    } else {
      // it's a page
      return [docsStructure];
    }
  }
}
```