### PR TITLE
Fix over scroll of navigation view items of docs page

### DIFF
--- a/src/lib/TreeView/TreeView.svelte
+++ b/src/lib/TreeView/TreeView.svelte
@@ -29,7 +29,7 @@
 	};
 </script>
 
-<div class="tree-view">
+<div class="tree-view scroller">
 	{#each tree as { name, path, type, pages, icon }}
 		{#if type === "category"}
 			<div class="subtree" class:expanded={treeViewState?.[id(name)]}>

--- a/src/routes/docs/__layout.svelte
+++ b/src/routes/docs/__layout.svelte
@@ -110,7 +110,7 @@
 </svelte:head>
 
 <section class="docs">
-	<aside class="sidebar scroller">
+	<aside class="sidebar">
 		<div class="search">
 			<div
 				class="autosuggest-wrapper"


### PR DESCRIPTION
## Description
Fix over scroll on docs page

## Reproduce
1. Go to: https://files.community/docs
2. Reduce the window size vertically until the scroll bar appears.
3. Scroll to reproduce the screenshot below.

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/62196528/142734951-b91ae702-3b42-4ee1-9098-6f7cb9038cc3.png)
After:
![image](https://user-images.githubusercontent.com/62196528/142735033-17b3dc53-d26e-4b31-87e7-9b0f712ead61.png)