### PR TITLE
Fix the clarity script

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -114,16 +114,12 @@
 	<meta content="@FilesForWindows" name="twitter:site" />
 	<meta content="@FilesForWindows" name="twitter:creator" />
 
-	<script>
-		window["clarity"] = window["clarity"] || (() => {
-			(window["clarity"].q = window["clarity"].q || []).push(arguments);
-		});
-
-		let t = document.createElement("script");
-		t.async = true;
-		t.src = "https://www.clarity.ms/tag/4q1wajdktz";
-		let y = document.getElementsByTagName("script")[0];
-		y.parentNode.insertBefore(t, y);
+	<script type="text/javascript">
+		(function(c,l,a,r,i,t,y){
+			c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+			t=l.createElement(r);t.async=true;t.src="https://www.clarity.ms/tag/"+i;
+			y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+		})(window, document, "clarity", "script", "4q1wajdktz");
 	</script>
 </svelte:head>
 


### PR DESCRIPTION
## Description
Fixes the clarity `<script>` tag in the main layout.
This is copied directly from the Clarity dashboard, so if this doesn't work, the problem is with MS.

## Motivation and Context
@yaichenbaum asked me to, so we can have data