### PR TITLE
Auto-update the copyright year

### DIFF
--- a/src/layout/Footer/Footer.svelte
+++ b/src/layout/Footer/Footer.svelte
@@ -45,7 +45,7 @@
 				{@html Discord}
 			</IconButton>
 		</div>
-		<p>Copyright © 2021, The Files Authors</p>
+		<p>Copyright © {new Date().getFullYear()}, The Files Authors</p>
 	</div>
 	<div class="column">
 		<p>Pages</p>

--- a/src/layout/Footer/Footer.svelte
+++ b/src/layout/Footer/Footer.svelte
@@ -45,7 +45,7 @@
 				{@html Discord}
 			</IconButton>
 		</div>
-		<p>Copyright © {new Date().getFullYear()}, The Files Authors</p>
+		<p>Copyright © 2021 - {new Date().getFullYear()}, The Files Authors</p>
 	</div>
 	<div class="column">
 		<p>Pages</p>


### PR DESCRIPTION
## Description
The copyright year in the footer hasn't been updated to 2022, this PR inserts the current year (from the JS Date API) into the footer instead of hardcoding it.

## Motivation and Context
Mostly to automate this easily-forgettable process.

## Screenshots (if appropriate):
![a copyright disclaimer showing the current year](https://user-images.githubusercontent.com/65342367/150680434-aad5801b-f8aa-4e11-b3b6-64d999e2bb2b.png)