### PR TITLE
Fix eye icon

### DIFF
--- a/src/data/features.ts
+++ b/src/data/features.ts
@@ -1,7 +1,7 @@
 import Cloud from "@fluentui/svg-icons/icons/cloud_24_regular.svg?raw";
 import Tag from "@fluentui/svg-icons/icons/tag_24_regular.svg?raw";
 import TabDesktop from "@fluentui/svg-icons/icons/tab_desktop_20_regular.svg?raw";
-import EyeVisible from "@fluentui/svg-icons/icons/eye_show_20_regular.svg?raw";
+import EyeVisible from "@fluentui/svg-icons/icons/eye_20_regular.svg?raw";
 
 export interface FeatureCardData {
 	title: string;


### PR DESCRIPTION
## Description
There was a breaking change in the fluent icons packages which renamed the `eye_show` icon to `eye`.