### PR TITLE
Fix file extension on docs edit button

### DIFF
--- a/src/routes/docs/__layout.svelte
+++ b/src/routes/docs/__layout.svelte
@@ -212,7 +212,7 @@
 						<Button variant="hyperlink"
 						        href="https://github.com/{links.github.owner}/{links.github
 								.siteRepo}/edit/main/src/routes/docs{currentPage.path ||
-								'/index'}.svx"
+								'/index'}.md"
 						        {...externalLink}
 						>
 							Edit this page


### PR DESCRIPTION
## Description
The edit docs button still linked to the old *.svx files, this is fixed now. 

## Motivation and Context
It made the button link to a dead link.