### PR TITLE
Removes Git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-pnpm up
-git add package.json
-git add pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
-		"format": "prettier --write --plugin-search-dir=. .",
-		"prepare": "husky install"
+		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
 		"@fec/remark-a11y-emoji": "^3.1.0",
@@ -26,7 +25,6 @@
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-svelte3": "^3.4.0",
 		"fluent-svelte": "^1.3.3",
-		"husky": "^7.0.4",
 		"postcss": "^8.4.6",
 		"mdsvex": "^0.10.5",
 		"postcss-media-minmax": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,7 @@ specifiers:
   eslint-config-prettier: ^8.3.0
   eslint-plugin-svelte3: ^3.4.0
   fluent-svelte: ^1.3.3
-  husky: ^7.0.4
-  mdsvex: ^0.9.8
+  mdsvex: ^0.10.5
   postcss: ^8.4.6
   postcss-media-minmax: ^5.0.0
   prettier: ^2.5.1
@@ -44,8 +43,7 @@ devDependencies:
   eslint-config-prettier: 8.3.0_eslint@8.8.0
   eslint-plugin-svelte3: 3.4.0_eslint@8.8.0+svelte@3.46.4
   fluent-svelte: 1.3.3
-  husky: 7.0.4
-  mdsvex: 0.9.8_svelte@3.46.4
+  mdsvex: 0.10.5_svelte@3.46.4
   postcss: 8.4.6
   postcss-media-minmax: 5.0.0_postcss@8.4.6
   prettier: 2.5.1
@@ -1244,12 +1242,6 @@ packages:
       function-bind: 1.1.1
     dev: true
 
-  /husky/7.0.4:
-    resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dev: true
-
   /ignore/4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
     engines: {node: '>= 4'}
@@ -1482,8 +1474,8 @@ packages:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
     dev: true
 
-  /mdsvex/0.9.8_svelte@3.46.4:
-    resolution: {integrity: sha512-5QvThjRKoKkGH00qdHxLZ5ROd80RgGiJvM2B9opeFreaiGFTLoKKFUgEBCslLrwM24cVGJLmIM3rR83OFDf3tQ==}
+  /mdsvex/0.10.5_svelte@3.46.4:
+    resolution: {integrity: sha512-/B23WZn5Vjrjh7Qp2YsOXLkU9YFm59IEylKNXC10o05ZaCP4LNv32tGXKP6aEssss6hk/LdISJuneELHFIS2pQ==}
     peerDependencies:
       svelte: 3.x
     dependencies:


### PR DESCRIPTION
## Description
Removes the `husky` package and the pre-commit hook which updated the dependencies with `pnpm up` with every commit.

## Motivation and Context
At first it seemed like a good idea, but with numerous breaking changes in SvelteKit breaking the app, updating dependencies blindly and assuming no breaking changes will come was a dangerous idea.
