### PR TITLE
Fixes #159

### DIFF
--- a/src/layout/HeroSection/HeroSection.svelte
+++ b/src/layout/HeroSection/HeroSection.svelte
@@ -38,14 +38,6 @@
 	const changeDownloadSource = (downloadSource: DownloadSource) => {
 		currentDownloadSource = downloadSource;
 		localStorage.setItem("downloadSource", downloadSource);
-
-		if (downloadSource !== "Winget (CLI)") {
-			window.open(downloadSource === "Microsoft Store" ? getStoreUrl() : sideloadLink, "_blank");
-		} else {
-			wingetDialogOpen = true;
-		}
-
-		isDownloadDropdownOpen = false;
 	};
 
 	onMount(async () => {


### PR DESCRIPTION
## Description

Selecting an item from the hero button dropdown does not open a new browser window or a popup window any more. This was an unexpected behavior and I just removed the functionality that was making it happen.

I don't know why, but this code was making the dropdown open again, instead of closing it! I removed it and now it works fine😂🤷‍♂️

```js
isDownloadDropdownOpen = false;
```
