### PR TITLE
fix: currentDownloadSource showing undefined

### DIFF
--- a/src/layout/HeroSection/HeroSection.svelte
+++ b/src/layout/HeroSection/HeroSection.svelte
@@ -50,7 +50,7 @@
 
 	onMount(async () => {
 		// Get the user's download preference
-		if (!downloadSources.includes(localStorage.getItem("downloadSource") as DownloadSource)) {
+		if (!downloadSources.includes((localStorage.getItem("downloadSource") ?? "") as DownloadSource)) {
 			localStorage.setItem("downloadSource", "Microsoft Store");
 		}
 		currentDownloadSource = (localStorage.getItem("downloadSource") ?? "Microsoft Store") as DownloadSource;

--- a/src/layout/HeroSection/HeroSection.svelte
+++ b/src/layout/HeroSection/HeroSection.svelte
@@ -50,7 +50,7 @@
 
 	onMount(async () => {
 		// Get the user's download preference
-		if (!localStorage.getItem("downloadSource")) {
+		if (!downloadSources.includes(localStorage.getItem("downloadSource") as DownloadSource)) {
 			localStorage.setItem("downloadSource", "Microsoft Store");
 		}
 		currentDownloadSource = (localStorage.getItem("downloadSource") ?? "Microsoft Store") as DownloadSource;


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Added a value check to the localstorage fallback.
## Motivation and Context
<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->
If the user previously visited an old version of the files website their localstorage would hold an invalid value for the key `downloadSource` [number] it would display `undefined`. This issue was introduced in [this](https://github.com/files-community/Website/commit/4d469fc989c4223f6b1ad05160ac2d006fa73395) commit

## Screenshots (if appropriate):
<!-- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![image](https://user-images.githubusercontent.com/6506529/171282157-724aebeb-6d13-434d-b396-f9a54953e1da.png)
