### PR TITLE
Remove only available on sideload version as false

### DIFF
--- a/src/routes/docs/configuring/replace-file-explorer.md
+++ b/src/routes/docs/configuring/replace-file-explorer.md
@@ -5,7 +5,6 @@ Please keep in mind that these changes are not reverted when removing the app so
 
 **Settings Files as the default file manager**
 
-*This is currently only available for the sideload version of Files and is not supported in the store version.*
 1. Open the settings dialog in Files
 2. Navigate to the experimental section and toggle the switch to set Files as the default file manager
 


### PR DESCRIPTION
## Description
Remove only available on sideloaded version as it is false

## Motivation and Context
As the text "Only available on sideloaded version and not the store version" is completely false

## Screenshots (if appropriate):
Here is a screenshot of the store's version experimental setting tab :
![image](https://user-images.githubusercontent.com/68708992/175015003-e17a7845-373f-4668-a3dd-be17e0742cfa.png)

And here is the documentation :
![image](https://user-images.githubusercontent.com/68708992/175015259-33598976-6b91-42b5-aecb-0913ad69098d.png)
