### PR TITLE
Fixes horizontal scrollbar issue in Firefox

### DIFF
--- a/src/layout/CommunitySection/CommunitySection.scss
+++ b/src/layout/CommunitySection/CommunitySection.scss
@@ -61,6 +61,7 @@
 		0 20.5812px 20.5812px hsl(0, 0%, 0%, 6%),
 		0 41.1623px 41.1623px hsl(0, 0%, 0%, 7%),
 		0 96.0454px 89.1851px hsl(0, 0%, 0%, 9%);
+		overflow: hidden;
 
 		.rainbow-background {
 			position: absolute;


### PR DESCRIPTION
## Description
This is caused by the `inline-size: 100vw;` property on the `contributors-container` class.
This is because 100vw doesn't include the scrollbar width so It's `100vw + scrollbar width`.

The contributors container is now cut off at the parent container instead on the viewport width.

## Motivation and Context
Closes #235 

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/34947993/179622002-d2c5a5ed-446f-443c-a127-cce32c6d1af5.png)

After:
![image](https://user-images.githubusercontent.com/34947993/179622041-64527ab5-30f4-4457-ab2a-51dcd71469b1.png)
