### PR TITLE
Fix docs/overview typo and broken link

### DIFF
--- a/src/routes/docs/+page.md
+++ b/src/routes/docs/+page.md
@@ -4,10 +4,10 @@ Files is a modern file manager that helps organize your files and folders easily
 ## What makes Files unique?
 Files has a clean UI that is designed for ease of use, this enables everyone including beginners to take advantage of the rich set of features we built.
 
-## Accessability
-Accessability is one of our top priorities and we're proud of the fact that Files is designed to work with screen readers, keyboard navigation and high contrast modes.
+## Accessibility
+Accessibility is one of our top priorities and we're proud of the fact that Files is designed to work with screen readers, keyboard navigation and high contrast modes.
 
 ## Download Files
 - [Download Files](/download/stable)
 - [Download Preview Build](/download/preview)
-- [Download from the Microsoft Store]({'https://www.microsoft.com/store/apps/9nghp3dx8hdx?cid=FilesWebsite'})
+- [Download from the Microsoft Store](https://www.microsoft.com/store/apps/9nghp3dx8hdx?cid=FilesWebsite)


### PR DESCRIPTION
The word "Accessibility" was incorrect, and the MS Store link was broken when viewing the file on GitHub (not sure if intentional, but it should work for both now)

## Description
Fixed the typo and broken link.