### PR TITLE
Removed the note about Firefox adding extensions to installers

### DIFF
--- a/src/routes/download/+layout.svelte
+++ b/src/routes/download/+layout.svelte
@@ -9,12 +9,9 @@
 
 	let link: HTMLAnchorElement;
 
-	let firefox = false;
-
 	const downloadAppInstaller = () => link.click();
 
 	onMount(() => {
-		firefox = navigator.userAgent.includes("Firefox");
 		if (!dev) downloadAppInstaller();
 	});
 </script>
@@ -35,13 +32,6 @@
 		</a>
 		to start it:
 	</p>
-
-	{#if firefox}
-		<InfoBar severity="caution" closable={false}>
-			Firefox adds a <code>.xml</code> file extension to the downloaded installer.
-			Remove it before opening the installer.
-		</InfoBar>
-	{/if}
 
 	<p>Want to support the creators of Files?</p>
 	<Button


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Removed the note in the download page about Firefox adding extensions to installers.

## Motivation and Context
<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->
This was fixed recently (https://bugzilla.mozilla.org/show_bug.cgi?id=1773907).
Closes #267

## Screenshots (if appropriate):
<!-- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->