### PR TITLE
Fix: page titles were replaced with `undefined` in search results

### DIFF
--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -113,9 +113,9 @@
 				{#if autoSuggestVisible}
 					<div class="autosuggest-flyout scroller">
 						{#if searchResults.length > 0}
-							{#each searchResults as { name, path }, i}
+							{#each searchResults as { title, path }, i}
 								<ListItem selected={selection === i} href="/docs{path}">
-									{name}
+									{title}
 								</ListItem>
 							{/each}
 						{:else}


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
All pages appeared as `undefined` in the docs search results.

## Motivation and Context
<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->
I forgot to check this before merging #253 :smiling_face_with_tear: 
