### PR TITLE
Fix metadata duplication.

### DIFF
--- a/src/lib/Metadata.svelte
+++ b/src/lib/Metadata.svelte
@@ -6,9 +6,11 @@
 	$: imageFile = image.startsWith("/") ? image : `/branding/banner${image === "" ? "" : "-" + image}.png`
 </script>
 
-<title>{title}</title>
-<meta content={title} name="og:title">
-<meta content={title} name="twitter:title">
+<svelte:head>
+	<title>{title}</title>
+	<meta content={title} name="og:title">
+	<meta content={title} name="twitter:title">
 
-<meta content={imageFile} name="og:image">
-<meta content="https://{$page.url.host}{imageFile}" name="twitter:image">
+	<meta content={imageFile} name="og:image">
+	<meta content="https://{$page.url.host}{imageFile}" name="twitter:image">
+</svelte:head>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -9,9 +9,7 @@
 	};
 </script>
 
-<svelte:head>
-	<Metadata />
-</svelte:head>
+<Metadata />
 
 <section class="error-page">
 	<div class="window" use:draggable={draggableOptions}>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,9 +3,7 @@
 	import { Metadata } from "$lib";
 </script>
 
-<svelte:head>
-	<Metadata title="Files • Home" />
-</svelte:head>
+<Metadata title="Files • Home" />
 
 <DesignSection />
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -10,9 +10,7 @@
 	let scrollY: number;
 </script>
 
-<svelte:head>
-	<Metadata title="Files • Blog" image="blog" />
-</svelte:head>
+<Metadata title="Files • Blog" image="blog" />
 
 <svelte:window
 	on:scroll={() =>

--- a/src/routes/blog/posts/+layout.svelte
+++ b/src/routes/blog/posts/+layout.svelte
@@ -11,9 +11,7 @@
 	$: ({ title, thumbnail, author, date } = data);
 </script>
 
-<svelte:head>
-	<Metadata title="Files • {title}" image={thumbnail} />
-</svelte:head>
+<Metadata title="Files • {title}" image={thumbnail} />
 
 <section class="blog-post">
 	<article>

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -77,12 +77,10 @@
 	};
 </script>
 
-<svelte:head>
-	<Metadata
-		title="Files • {pageTitle ? `Docs - ${pageTitle}` : 'Docs'}"
-		image="docs"
-	/>
-</svelte:head>
+<Metadata
+	title="Files • {pageTitle ? `Docs - ${pageTitle}` : 'Docs'}"
+	image="docs"
+/>
 
 <section class="docs">
 	<aside class="sidebar">

--- a/src/routes/download/+page.svelte
+++ b/src/routes/download/+page.svelte
@@ -40,9 +40,7 @@
 	});
 </script>
 
-<svelte:head>
-	<Metadata title="Files • Download" image="download" />
-</svelte:head>
+<Metadata title="Files • Download" image="download" />
 
 <slot />
 

--- a/src/routes/themes/+page.svelte
+++ b/src/routes/themes/+page.svelte
@@ -2,8 +2,6 @@
 	import { Metadata } from "$lib";
 </script>
 
-<svelte:head>
-	<Metadata title="Files • Themes" image="themes" />
-</svelte:head>
+<Metadata title="Files • Themes" image="themes" />
 
 todo


### PR DESCRIPTION
## Description
This PR aims to fix the `<head>` metadata duplication.

## Motivation and Context
Svelte has an unexpected behavior that if you put components inside `<svelte:head>` and deploy your website using SSR, the contents would be duplicated if you navigate from one page to another. While this may or may not cause a problem with search engine crawlers or Open Graph crawlers, it does cause some minor annoyances. Most notably, browsers would show the wrong title for the page since it pulls the first `<title>` tag that exists on the site.

## Additional notes
This PR doesn't fix a problem with the `twitter:image` metadata tag where `page.url.host` would return `sveltekit-prerender` on browsers without JavaScript (which include Twitter embed crawlers).