### PR TITLE
Fix: Issue links not going to issue templates

### DIFF
--- a/src/layout/Footer/Footer.svelte
+++ b/src/layout/Footer/Footer.svelte
@@ -88,7 +88,7 @@
 			variant="hyperlink"
 			{...externalLink}
 			href="https://github.com/{links.github.owner}/{links.github
-				.repo}/issues/new"
+				.repo}/issues/new/choose"
 		>
 			Give Feedback
 		</Button>
@@ -118,7 +118,7 @@
 			variant="hyperlink"
 			{...externalLink}
 			href="https://github.com/{links.github.owner}/{links.github
-				.siteRepo}/issues/new"
+				.siteRepo}/issues/new/choose"
 		>
 			Found a bug?
 		</Button>


### PR DESCRIPTION
## Description
Added `/choose`  to the end of feedback URLs

## Motivation and Context
<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->
Closes #326

## Screenshots (if appropriate):
<!-- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->