### PR TITLE
Fix: bug when navigate directly to /docs/ url

### DIFF
--- a/src/layout/DesignSection/DesignSection.svelte
+++ b/src/layout/DesignSection/DesignSection.svelte
@@ -18,7 +18,7 @@
 		<Button href="/download/" variant="accent">
 			{$_("home.design.download", defaultI18nValues)}
 		</Button>
-		<Button variant="hyperlink" href="/docs/">
+		<Button variant="hyperlink" href="/docs">
 			{$_("home.design.learn_more", defaultI18nValues)}
 		</Button>
 	</div>


### PR DESCRIPTION
## Description
I removed the final slash from button (Learn more) link in [home page](https://files.community/).

## Motivation and Context
The page doesn't load well when you navigate directly to https://files.community/docs/ in a new window or tab.

It gives error because tries to get the files from https://files.community/docs/_app/immutable/...
instead of https://files.community/_app/immutable/...

## Screenshots:
https://files.community/docs/
![image](https://user-images.githubusercontent.com/13784162/223175282-d7c9403b-84e7-4152-bf63-090d43076092.png)


https://files.community/docs
![image](https://user-images.githubusercontent.com/13784162/223175368-b8e4f07d-0e7b-4f81-99b9-75def36aaed8.png)