### PR TITLE
Fix scroll depending animations due to wrong scroll listener

### DIFF
--- a/src/layout/DesignSection/DesignSection.svelte
+++ b/src/layout/DesignSection/DesignSection.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import { defaultI18nValues, HeaderChip, PageSection } from "$lib";
 	import { Button } from "fluent-svelte";
+	import { onMount } from "svelte";
 	import { _ } from "svelte-i18n";
 	let scrollY: number;
-</script>
 
-<svelte:window
-	on:scroll={() =>
-		window.requestAnimationFrame(() => (scrollY = window.scrollY))}
-/>
+	onMount(() => {
+		const body = document.getElementsByTagName("body")[0];
+		body.addEventListener("scroll", () => {
+			scrollY = body.scrollTop;
+		});
+	});
+</script>
 
 <PageSection id="design-section">
 	<HeaderChip>{$_("home.design.chip", defaultI18nValues)}</HeaderChip>

--- a/src/layout/DesignSection/DesignSection.svelte
+++ b/src/layout/DesignSection/DesignSection.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
 	import { defaultI18nValues, HeaderChip, PageSection } from "$lib";
 	import { Button } from "fluent-svelte";
-	import { onMount } from "svelte";
 	import { _ } from "svelte-i18n";
-	let scrollY: number;
-
-	onMount(() => {
-		const body = document.getElementsByTagName("body")[0];
-		body.addEventListener("scroll", () => {
-			scrollY = body.scrollTop;
-		});
-	});
+	let scrollPositionY: number;
 </script>
+
+<svelte:body on:scroll={() => (scrollPositionY = document.body.scrollTop)} />
 
 <PageSection id="design-section">
 	<HeaderChip>{$_("home.design.chip", defaultI18nValues)}</HeaderChip>
@@ -40,7 +34,7 @@
 				class="files-screenshot"
 				height="768"
 				src="/screenshots/folder-list-light.png"
-				style:transform="translateY({Math.floor(scrollY / +20)}px)"
+				style:transform="translateY({Math.floor(scrollPositionY / +20)}px)"
 				width="1024"
 			/>
 		</picture>

--- a/src/layout/ThemesSection/ThemesSection.svelte
+++ b/src/layout/ThemesSection/ThemesSection.svelte
@@ -58,11 +58,11 @@
 	)
 		visible = true;
 
-	const handleThemeChange = (e: MediaQueryListEvent) => {
-		systemTheme = e.matches ? "dark" : "light";
-	};
-
 	onMount(() => {
+		const handleThemeChange = (e: MediaQueryListEvent) => {
+			systemTheme = e.matches ? "dark" : "light";
+		};
+
 		visible = false; // We want SSR to have these visible by default, so we'll just do this.
 
 		systemTheme = window?.matchMedia("(prefers-color-scheme: dark)")?.matches

--- a/src/layout/ThemesSection/ThemesSection.svelte
+++ b/src/layout/ThemesSection/ThemesSection.svelte
@@ -67,10 +67,15 @@
 			.addEventListener("change", e => {
 				systemTheme = e.matches ? "dark" : "light";
 			});
+
+		const body = document.getElementsByTagName("body")[0];
+		body.addEventListener("scroll", () => {
+			scrollY = body.scrollTop;
+		});
 	});
 </script>
 
-<svelte:window bind:innerHeight bind:scrollY />
+<svelte:window bind:innerHeight />
 
 <PageSection class="theme-{currentTheme + 1}" id="themes-section">
 	<div bind:this={anchor} class="scroll-anchor" />

--- a/src/layout/ThemesSection/ThemesSection.svelte
+++ b/src/layout/ThemesSection/ThemesSection.svelte
@@ -9,10 +9,11 @@
 	import { TextBlock } from "fluent-svelte";
 	import { _ } from "svelte-i18n";
 	import type { Tag } from "$data/features";
+	import { error } from "@sveltejs/kit";
 
 	let systemTheme = "light";
 	let currentTheme = 0;
-	let scrollY = 0;
+	let scrollPositionY = 0;
 	let innerHeight = 0;
 	let visible = true;
 	let noInitialDelay = false;
@@ -50,8 +51,10 @@
 	// Essentially determines if the user has seen the top 1/4th of the themes section or not
 	$: if (
 		anchor &&
-		anchor.getBoundingClientRect().top + anchor.offsetHeight / 4 + scrollY <
-			scrollY + innerHeight
+		anchor.getBoundingClientRect().top +
+			anchor.offsetHeight / 4 +
+			scrollPositionY <
+			scrollPositionY + innerHeight
 	)
 		visible = true;
 
@@ -67,15 +70,11 @@
 			.addEventListener("change", e => {
 				systemTheme = e.matches ? "dark" : "light";
 			});
-
-		const body = document.getElementsByTagName("body")[0];
-		body.addEventListener("scroll", () => {
-			scrollY = body.scrollTop;
-		});
 	});
 </script>
 
 <svelte:window bind:innerHeight />
+<svelte:body on:scroll={() => (scrollPositionY = document.body.scrollTop)} />
 
 <PageSection class="theme-{currentTheme + 1}" id="themes-section">
 	<div bind:this={anchor} class="scroll-anchor" />

--- a/src/layout/ThemesSection/ThemesSection.svelte
+++ b/src/layout/ThemesSection/ThemesSection.svelte
@@ -58,6 +58,10 @@
 	)
 		visible = true;
 
+	const handleThemeChange = (e: MediaQueryListEvent) => {
+		systemTheme = e.matches ? "dark" : "light";
+	};
+
 	onMount(() => {
 		visible = false; // We want SSR to have these visible by default, so we'll just do this.
 
@@ -67,9 +71,12 @@
 
 		window
 			.matchMedia("(prefers-color-scheme: dark)")
-			.addEventListener("change", e => {
-				systemTheme = e.matches ? "dark" : "light";
-			});
+			.addEventListener("change", handleThemeChange);
+
+		return () =>
+			window
+				.matchMedia("(prefers-color-scheme: dark)")
+				.removeEventListener("change", handleThemeChange);
 	});
 </script>
 


### PR DESCRIPTION
## Description

Since the scrolling is not done on the window but rather the body, listening to window scroll events does not work. We fix this by listening to the body element for the scroll events.

## Motivation and Context

Closes #428

## Screenshots (if appropriate):
