### PR TITLE
re-enabled dependabot since it now supports pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - pacakge-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday" # i have time to review everything on this day
+    commit-message:
+      prefix: "Dependabot: "
+      include: "scope"
+    pull-request-branch-name:
+      seperator: "/"
+    reviewers:
+      - "theonlytails"


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
dependabot [supports pnpm now](https://github.blog/changelog/2023-06-12-dependabot-version-updates-now-supports-pnpm/) so this will let us safely keep track of dependency updates.
