### PR TITLE
Feature: Added the description of blog posts to their meta tags

### DIFF
--- a/src/routes/blog/posts/+layout.svelte
+++ b/src/routes/blog/posts/+layout.svelte
@@ -9,9 +9,13 @@
 
 	export let data: LayoutData;
 
-	$: ({ title, thumbnail, author, date } = data);
+	$: ({ title, thumbnail, author, description, date } = data);
 	$: pageTitle = title;
 </script>
+
+<svelte:head>
+	<meta name="description" content={description} />
+</svelte:head>
 
 <Metadata
 	title={pageTitle


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
Adds the description of blog posts into the `description` meta tag, allowing it to show up in places like Discord embeds and Twitter cards, etc.
