### PR TITLE
Remove Requires Windows 11 Only text from Glass theme

### DIFF
--- a/src/routes/docs/configuring/custom-themes/+page.md
+++ b/src/routes/docs/configuring/custom-themes/+page.md
@@ -32,7 +32,7 @@ Files has built-in support for custom fonts, to apply a custom font start by ope
 
 We put together some popular color combinations to help users create custom themes.
 
-#### **Glass (requires Windows 11)**
+#### **Glass**
 
 | Key                                 | Value       |
 | ----------------------------------- | ----------- |


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
The text stating that the Glass theme requires Windows 11 has been removed.

## Motivation and Context

<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->
Glass theme is now available on Windows 10 as well thanks to Acrylic support being added.

## Screenshots (if appropriate):

<!-- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
