### PR TITLE
Docs: Add ownCloud to supported cloud drives list

### DIFF
--- a/src/routes/docs/configuring/cloud-drives/+page.md
+++ b/src/routes/docs/configuring/cloud-drives/+page.md
@@ -63,3 +63,7 @@ https://www.seafile.com/en/download/
 ## Autodesk
 
 https://drive.autodesk.com/
+
+## ownCloud
+
+https://owncloud.com/


### PR DESCRIPTION
Adds Owncloud to supported cloud drives list

## Motivation and Context

Support for ownCloud drive was added to Files in https://github.com/files-community/Files/pull/12896