### PR TITLE
Feature: Enable data preloading on all links in the site

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
 		%sveltekit.head%
 	</head>
 
-	<body>
+	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/layout/Footer/Footer.svelte
+++ b/src/layout/Footer/Footer.svelte
@@ -28,7 +28,7 @@
 
 <PageSection type="footer" id="page-footer">
 	<div class="column">
-		<a class="logo" href="/" data-sveltekit-preload-data="hover">
+		<a class="logo" href="/">
 			<picture>
 				<source
 					media="(prefers-color-scheme: dark)"
@@ -73,28 +73,16 @@
 	</div>
 	<div class="column">
 		<p>Pages</p>
-		<Button variant="hyperlink" data-sveltekit-preload-data="hover" href="/">
+		<Button variant="hyperlink" href="/">
 			{$_("footer.home", defaultI18nValues)}
 		</Button>
-		<Button
-			variant="hyperlink"
-			data-sveltekit-preload-data="hover"
-			href="/docs"
-		>
+		<Button variant="hyperlink" href="/docs">
 			{$_("footer.docs", defaultI18nValues)}
 		</Button>
-		<Button
-			variant="hyperlink"
-			data-sveltekit-preload-data="hover"
-			href="/blog"
-		>
+		<Button variant="hyperlink" href="/blog">
 			{$_("footer.news", defaultI18nValues)}
 		</Button>
-		<Button
-			variant="hyperlink"
-			data-sveltekit-preload-data="hover"
-			href="/download"
-		>
+		<Button variant="hyperlink" href="/download">
 			{$_("footer.download", defaultI18nValues)}
 		</Button>
 	</div>

--- a/src/layout/Navbar/Navbar.svelte
+++ b/src/layout/Navbar/Navbar.svelte
@@ -52,7 +52,7 @@
 
 <header class="navbar">
 	<nav class="inner">
-		<a class="logo" href="/" data-sveltekit-preload-data="hover">
+		<a class="logo" href="/">
 			<picture>
 				<source
 					media="(prefers-color-scheme: dark)"
@@ -80,7 +80,6 @@
 				{:else}
 					<a
 						class="item"
-						data-sveltekit-preload-data="hover"
 						class:selected={isUrlContainPath($page.url.pathname, path)}
 						href={path}
 						target={external ? "_blank" : undefined}
@@ -140,7 +139,6 @@
 			{:else if !sidebarTree}
 				<ListItem
 					type="navigation"
-					data-sveltekit-preload-data="hover"
 					on:click={toggleSidebar}
 					selected={isUrlContainPath($page.url.pathname, path)}
 					href={path}
@@ -170,12 +168,7 @@
 		{/each}
 		<hr />
 		{#each buttons as { icon, href, label }}
-			<ListItem
-				{href}
-				data-sveltekit-preload-data="hover"
-				type="navigation"
-				{...externalLink}
-			>
+			<ListItem {href} type="navigation" {...externalLink}>
 				<svelte:fragment slot="icon">
 					{#if icon}
 						<svelte:component this={icon} />


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
Data preloading has now been enabled on all links in the app, which will run the data loading logic for a page as soon as a link pointing to it is hovered on.

## Motivation and Context

<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->
I noticed that images were loading a bit slowly on the blog page and some docs pages, and this should help mitigate that.
