### PR TITLE
Update +page.md correction of search example

### DIFF
--- a/src/routes/docs/configuring/tags/+page.md
+++ b/src/routes/docs/configuring/tags/+page.md
@@ -31,8 +31,8 @@ You can also click tags in the details layout to start a search. To do that, fol
 
 To search for tags, follow these steps:
 
-- Tap on the search box and type in `tag:` followed by the name of the tag, for example `tag: Photos`
-- You can search for multiple tags at once by separating tag names with a comma and space. For example `tag: Photos, Important`
+- Tap on the search box and type in `tag:` followed by the name of the tag, for example `tag:Photos`
+- You can search for multiple tags at once by separating tag names with a comma and space. For example `tag:Photos, Important`
 
 ## How to edit or delete tags
 


### PR DESCRIPTION
## Description

The search example seems to not be functional (if a space after the "tag:", no result)
Version 3.0.1.0 Files Preview

## Motivation and Context

Documentation needs to be exact ^__^

## Screenshots (if appropriate):
![files_v3_tagsSearch](https://github.com/files-community/Website/assets/20887508/98712f17-bc9c-4886-a0d7-7c93c1cdbf72)

