### PR TITLE
Delete website's repository links

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -111,9 +111,6 @@
 		"feedback": "Give Feedback",
 		"style_guide": "Style Guide",
 		"translations": "Translations",
-		"contribute_site": "Contribute to this site",
-		"github": "Github Repo",
-		"report_bug": "Found a bug?",
 		"web_team": "Web Team"
 	},
 	"navbar": {

--- a/src/layout/Footer/Footer.svelte
+++ b/src/layout/Footer/Footer.svelte
@@ -108,24 +108,6 @@
 		>
 			{$_("footer.translations", defaultI18nValues)}
 		</Button>
-
-		<p>{$_("footer.contribute_site", defaultI18nValues)}</p>
-		<Button
-			variant="hyperlink"
-			{...externalLink}
-			href="https://github.com/{links.github.owner}/{links.github.siteRepo}/"
-		>
-			{$_("footer.github", defaultI18nValues)}
-		</Button>
-
-		<Button
-			variant="hyperlink"
-			{...externalLink}
-			href="https://github.com/{links.github.owner}/{links.github
-				.siteRepo}/issues/new/choose"
-		>
-			{$_("footer.report_bug", defaultI18nValues)}
-		</Button>
 	</div>
 	<div class="column">
 		<p>{$_("footer.web_team", defaultI18nValues)}</p>


### PR DESCRIPTION
## Description

Delete website's GitHub repository links.

## Motivation and Context

Remove them to avoid users mistakenly believing it is the app repository and mistakenly submitting app issues.