### PR TITLE
Edit docs search placeholder translatable

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -104,7 +104,8 @@
 	},
 	"docs": {
 		"autocomplete_empty": "No results found",
-		"edit_page": "Edit this page"
+		"edit_page": "Edit this page",
+		"search_docs": "Search Documentation"
 	},
 	"footer": {
 		"home": "Home",

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -77,7 +77,7 @@
 	title={pageTitle
 		? $_("metadata.docs_page", {
 				values: { title: pageTitle, FilesName: "Files" },
-		  })
+			})
 		: $_("metadata.docs_home", defaultI18nValues)}
 	image="docs"
 />
@@ -105,7 +105,7 @@
 								keepFocus: true,
 							});
 					}}
-					placeholder="Search Documentation"
+					placeholder={$_("docs.search_docs", defaultI18nValues)}
 					type="search"
 				/>
 				{#if autoSuggestVisible}


### PR DESCRIPTION
## Description
There is a search section in the upper left corner of the /docs page. Its placeholder can be translated.
<!-- Describe your changes here -->

## Motivation and Context
We need to add more detailed translations to make it more convenient for international users.
<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->

## Screenshots (if appropriate):

<!-- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
