### PR TITLE
Blog: Include the author of posts again

### DIFF
--- a/src/routes/blog/posts/announcing-files-v2-4-30/+page.md
+++ b/src/routes/blog/posts/announcing-files-v2-4-30/+page.md
@@ -3,7 +3,7 @@ title: Introducing Files, version 2.4.30
 description: Better Home Page, Better Workflow
 thumbnail: /blog-resources/files2-4-30/HeroImage.jpg
 date: 2/7/2023
-author: files-community
+author: yaira2
 ---
 
 We are thrilled to announce the latest update to Files. With version 2.4.30, we've made several new improvements that will enhance your overall experience so be sure to update and see for yourself!

--- a/src/routes/blog/posts/announcing-files-v2-4-40/+page.md
+++ b/src/routes/blog/posts/announcing-files-v2-4-40/+page.md
@@ -3,7 +3,7 @@ title: Introducing Files, version 2.4.40
 description: Manage your files with tags
 thumbnail: /blog-resources/files2-4-40/HeroImage.jpg
 date: 2/20/2023
-author: files-community
+author: yaira2
 ---
 
 Files is a modern file manager app for Windows that offers a sleek and intuitive user interface with powerful features. In this post, we’ll take a look at some of the new features and improvements that we’ve added in version 2.4.40.

--- a/src/routes/blog/posts/announcing-files-v2-5-10/+page.md
+++ b/src/routes/blog/posts/announcing-files-v2-5-10/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files, version 2.5.10
 description: Details pane, Git columns, open in VS Code & more
 thumbnail: /blog-resources/files2-5-10/HeroImage.jpg
 date: 6/27/2023
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that version 2.5.10 is now available. If you already have Files, you'll get a notification in the app to update. Otherwise, you can download Files for free from our [download page](/download/).

--- a/src/routes/blog/posts/announcing-files-v2-5-20/+page.md
+++ b/src/routes/blog/posts/announcing-files-v2-5-20/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files, version 2.5.20
 description: Push Git commits to remote repositories, splash screen, updated icons, support for ownCloud.
 thumbnail: /blog-resources/files2-5-20/HeroImage.jpg
 date: 7/20/2023
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that version 2.5.20 is now available. If you already have Files, you'll get a notification in the app to update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) as a way to support the project.
@@ -22,7 +22,7 @@ To further improve our integration with Git, we're excited to be adding support 
 
 ### Improvements to the startup experience
 
-Startup performance is one of our highest priorities and something we're working on improving. We'd like the progress to be faster but unfortunately there are some limitations in the WinAppSdk framework. We hope these limitations will be resolved in future versions of WinAppSdk, but in the meantime, we've been working on a lot of smaller optimizations that we hope will add up over time. We're also adding a splash screen when the app is opened to indicate that the app is loading.  
+Startup performance is one of our highest priorities and something we're working on improving. We'd like the progress to be faster but unfortunately there are some limitations in the WinAppSdk framework. We hope these limitations will be resolved in future versions of WinAppSdk, but in the meantime, we've been working on a lot of smaller optimizations that we hope will add up over time. We're also adding a splash screen when the app is opened to indicate that the app is loading.
 
 <figure>
     <img src="/blog-resources/files2-5-20/SplashScreen.png" alt="Splash screen." />

--- a/src/routes/blog/posts/announcing-files-v2-5/+page.md
+++ b/src/routes/blog/posts/announcing-files-v2-5/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files, version 2.5
 description: Acrylic, git integration, preview pane & more
 thumbnail: /blog-resources/files2-5/HeroImage.jpg
 date: 6/13/2023
-author: files-community
+author: yaira2
 ---
 
 Today we're excited to announce the next major release of Files, version 2.5. If you already have Files, you'll get a notification in the app to update. Otherwise, you can download Files for free from our [download page](/download/).

--- a/src/routes/blog/posts/introducing-files-v2-3/+page.md
+++ b/src/routes/blog/posts/introducing-files-v2-3/+page.md
@@ -3,7 +3,7 @@ title: Introducing the next major release of Files - v2.3
 description: We're excited to not only introduce the next major release of Files, but also a series of future changes to sustain contributor momentum into 2023.
 thumbnail: /blog-resources/filesv2-3/HeroImage.jpg
 date: 2022-7-5
-author: files-community
+author: yaira2
 ---
 
 The astounding growth of the project over the last three years serves to motivate our journey to build the best file manager, alongside the community. More than ever, Files plays an important role in demonstrating how impactful the latest user experience improvements in WinUI can be. A notable experience we can reflect on was fixing an issue with screen reader accessibility reported by a blind user. More recently, we were delighted to hear from a seventy-seven-year-old "non-geek" who was impressed that we made file discovery "much easier" compared to the first party solution. Both of these stories highlight the inadvertent achievements that come from engaging the broader community.

--- a/src/routes/blog/posts/introducing-files-v2-4/+page.md
+++ b/src/routes/blog/posts/introducing-files-v2-4/+page.md
@@ -3,7 +3,7 @@ title: Introducing v2.4
 description: Taking a look at the features and improvements in Files v2.4
 thumbnail: /blog-resources/introducing-v2-4-preview/HeroImage.jpg
 date: 2022-12-26
-author: files-community
+author: yaira2
 ---
 
 We're pleased to announce that after a couple of weeks, v2.4 is available for all our users. Files has auto update built-in but if you're a new user or looking to manually update, you can download Files from our new [download page](/download/). Improved performance when navigating between directories, new features for managing archives and design changes are just some of the highlights for this release.

--- a/src/routes/blog/posts/introducing-v2-4-preview/+page.md
+++ b/src/routes/blog/posts/introducing-v2-4-preview/+page.md
@@ -3,7 +3,7 @@ title: Taking an early look at the next generation of Files
 description: We're excited to give you the first look at what we're working on for the next version of Files (v2.4).
 thumbnail: /blog-resources/introducing-v2-4-preview/HeroImage.jpg
 date: 2022-11-15
-author: files-community
+author: yaira2
 ---
 
 A couple of months ago, we announced our plans for the next generation of Files and we wanted to take this opportunity to share our progress on the transition from UWP to WinAppSdk. We're already seeing the benefits of this transition with faster build times, easier access to APIs and improved performance when navigating between directories. These noticeable improvements are just the start, there a lot additional ways for us to optimize and improve performance. Over the coming months, you can expect us to work on improving startup time and to reduce the amount of system resources being used when the app is open.

--- a/src/routes/blog/posts/listary-integration/+page.md
+++ b/src/routes/blog/posts/listary-integration/+page.md
@@ -3,7 +3,7 @@ title: Supercharge Your File Management with Files and Listary
 description: Experience unparalleled file management with the powerful integration of Files and Listary.
 thumbnail: /blog-resources/listary-integration/Hero.png
 date: 5/8/2024
-author: files-community
+author: yaira2
 ---
 
 ## Elevate your productivity with Listary
@@ -41,7 +41,6 @@ Once enabled, you'll have access to the following features:
 **Folder navigation**: A single click on a folder within the search results swiftly transports you there, opening it in the current tab or pane of Files.
 
 For comprehensive details and support concerning Listary, please visit their integration options page https://help.listary.com/options-integration#third-party-software-adapted-by-listary.
-
 
 ### Conclusion
 

--- a/src/routes/blog/posts/ten-things/+page.md
+++ b/src/routes/blog/posts/ten-things/+page.md
@@ -3,7 +3,7 @@ title: 10 Things You Didn't Know About Files
 description: Unlock the full potential of Files
 thumbnail: /blog-resources/ten-things/HeroImage.jpg
 date: 1/25/2023
-author: files-community
+author: yaira2
 ---
 
 Files is a powerful and user-friendly file manager that can help you organize and manage your files with ease. However, there may be some features and capabilities that you may not know about. In this post, we will highlight the top 10 things you may not know about Files.

--- a/src/routes/blog/posts/v3-1/+page.md
+++ b/src/routes/blog/posts/v3-1/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.1
 description: System tray icon, open minimized on startup, Smart Extract, prioritize files when sorting, and a new drag & drop gesture.
 thumbnail: /blog-resources/v3-1/Hero.png
 date: 1/8/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that starting today, Files v3.1 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
@@ -34,7 +34,7 @@ Smart Extract is a new feature that will automatically choose the extraction mod
 
 ### Prioritize files when sorting
 
-We added an option to prioritize files when sorting. Enabling this option will sort files and folders separately with files being placed at the top of the list. This feature is an addition to the existing options to "sort folders first" and "sort files and folders together". 
+We added an option to prioritize files when sorting. Enabling this option will sort files and folders separately with files being placed at the top of the list. This feature is an addition to the existing options to "sort folders first" and "sort files and folders together".
 
 <figure>
     <img src="/blog-resources/v3-1/SortFilesFirst.png" alt="Prioritize files when sorting" />

--- a/src/routes/blog/posts/v3-2-2/+page.md
+++ b/src/routes/blog/posts/v3-2-2/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.2.2
 description: A notification when app is running in the background, prompt when failing to rename items, and improvements to stability.
 thumbnail: /blog-resources/v3-2-2/Hero.png
 date: 2/19/2024
-author: files-community
+author: yaira2
 ---
 
 Files v3.2.2 is now available for download, this release contains bug fixes to enhance your file browsing experience. If you already have Files, the toolbar will display a notification to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.

--- a/src/routes/blog/posts/v3-2/+page.md
+++ b/src/routes/blog/posts/v3-2/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.2
 description: List View layout, edit album covers, higher quality thumbnails.
 thumbnail: /blog-resources/v3-2/Hero.png
 date: 2/12/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that starting today, Files v3.2 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
@@ -44,7 +44,6 @@ We’ve enhanced the resolution and contrast of our thumbnail previews to make t
     <img src="/blog-resources/v3-2/ThumbnailsTwo.png" alt="Thumbnail comparison" />
 </figure>
 
-
 ## Changes and Improvements
 
 - Added options to hide the built-in items from the right click context menu
@@ -62,7 +61,7 @@ We’ve enhanced the resolution and contrast of our thumbnail previews to make t
 - Fixed issue where renaming a tag wouldn't save the new name
 - Fixed issue where certain changes in the Properties Window couldn't be canceled
 - Fixed issue where switching from Details to Tiles would sometimes result in blurry icons
-- Fixed issue where thumbnails would sometimes fail to load for OneDrive items 
+- Fixed issue where thumbnails would sometimes fail to load for OneDrive items
 - Fixed issue where folder thumbnails wouldn't display a preview of the contents
 - Fixed issue where the Properties window was missing its icon
 - Fixed issue where search results would sometimes use the Columns View
@@ -91,7 +90,6 @@ We’ve enhanced the resolution and contrast of our thumbnail previews to make t
 - Fixed crash that would occur when selecting the address bar via `Shift` + `Tab`
 - Fixed crash that would occur when Git path contained an emoji
 - Fixed crash that could occur when dragging in grouped grid layout
-
 
 ### Conclusion
 

--- a/src/routes/blog/posts/v3-3/+page.md
+++ b/src/routes/blog/posts/v3-3/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.3
 description: Redesigned layout picker, additional spacing options, thumbnail improvements.
 thumbnail: /blog-resources/v3-3/Hero.png
 date: 3/19/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that starting today, Files v3.3 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
@@ -22,7 +22,6 @@ Beneath the the layout section, we added a slider to control the item sizes of t
     <img src="/blog-resources/v3-3/LayoutPicker.png" alt="Layout picker flyout" />
 </figure>
 
-
 ### Thumbnail performance and DPI support
 
 In v3.3, we continued working on thumbnail handling. While there is always room for improvement, you can anticipate a more reliable experience with fewer overall issues related to thumbnails.
@@ -33,7 +32,6 @@ When a thumbnail takes longer to load, a shimmer animation will be displayed to 
     <img src="/blog-resources/v3-3/SidebarIcons.png" alt="DPI aware sidebar icons" />
 </figure>
 
-
 ### Added a settings page to manage layout preferences
 
 We added a new settings page to simplify the management of your layout preferences. These options, formerly nested within submenus on the "Folders" settings page, are now more accessible and easier to locate. Additionally, the "Folders" page was renamed to "Files & folders".
@@ -42,11 +40,9 @@ We added a new settings page to simplify the management of your layout preferenc
     <img src="/blog-resources/v3-3/LayoutSettings.png" alt="Layout settings page" />
 </figure>
 
-
 ### Continue where you left off when restarting Windows
 
 Continue where you left off now works when Windows is restarted. Previously this feature only worked if you closed Files before restarting Windows.
-
 
 ## Changes and Improvements
 

--- a/src/routes/blog/posts/v3-4-1/+page.md
+++ b/src/routes/blog/posts/v3-4-1/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.4.1
 description: Support for displaying network drives on the sidebar, and general improvements to stability.
 thumbnail: /blog-resources/v3-4-1/Hero.png
 date: 5/14/2024
-author: files-community
+author: yaira2
 ---
 
 Files v3.4.1 is now available for download, this release contains bug fixes and improvements to enhance your file browsing experience. If you already have Files, the toolbar will display a notification to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
@@ -18,7 +18,6 @@ Files v3.4.1 is now available for download, this release contains bug fixes and 
 - Fixed an issue where the app wouldn’t run as admin
 - Fixed crash when connecting some removable drives
 - Fixed an issue where the string for "Actions" wasn't localize in the Settings menu
-
 
 ### Conclusion
 

--- a/src/routes/blog/posts/v3-4/+page.md
+++ b/src/routes/blog/posts/v3-4/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.4
 description: Enhance your Files experience with new features that allow you to filter file names, customize keyboard shortcuts, set a unique background image, and integrate with the powerful search utility, Listary.
 thumbnail: /blog-resources/v3-4/Hero.png
 date: 5/8/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that starting today, Files v3.4 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
@@ -28,7 +28,6 @@ Once selected, Files will update to display your image as a beautiful background
     <img src="/blog-resources/v3-4/BackgroundImage.png" alt="Custom background image" />
 </figure>
 
-
 ### Remap keyboard shortcuts
 
 We added a new settings page for Actions that enables you to personalize keyboard shortcuts. This feature lets you assign shortcuts to any action and offers the flexibility to modify existing key bindings. Customize your keyboard layout to enhance your workflow efficiency.
@@ -36,7 +35,6 @@ We added a new settings page for Actions that enables you to personalize keyboar
 <figure>
     <img src="/blog-resources/v3-4/Actions.png" alt="Actions settings page" />
 </figure>
-
 
 ### Filter file names in real-time
 
@@ -47,7 +45,6 @@ This real-time filtering saves time and is particularly beneficial for users who
 <figure>
     <img src="/blog-resources/v3-4/Filter.png" alt="Filter file names" />
 </figure>
-
 
 ### Added an integration with Listary
 
@@ -77,14 +74,13 @@ For additional details and support regarding Listary, you can visit their websit
 
 ### New localizations added
 
-Responding to user requests, we’ve expanded our language support to include Albanian, Khmer, Kurdish, and Lithuanian.  Our localizations are largely maintained by our dedicated community members. If you'd like to get involved, we invite you to join us on Crowdin https://crowdin.com/project/files-app.
-
+Responding to user requests, we’ve expanded our language support to include Albanian, Khmer, Kurdish, and Lithuanian. Our localizations are largely maintained by our dedicated community members. If you'd like to get involved, we invite you to join us on Crowdin https://crowdin.com/project/files-app.
 
 ## Changes and Improvements
 
 - The Recent Files widget now respects the setting for displaying file extensions
 - Improved the display of keyboard shortcuts in the Command Palette
-- Added support to the sidebar for multiple SharePoint drives 
+- Added support to the sidebar for multiple SharePoint drives
 - Added an integration for the Lucid Link cloud provider
 - Added audio bitrate, and video to the list of properties in the Details Pane
 - Fixed an issue where pinned items weren't displayed in the sidebar

--- a/src/routes/blog/posts/v3-5/+page.md
+++ b/src/routes/blog/posts/v3-5/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.5
 description: Enjoy an updated design, network drive widget, enhanced dual-pane functionality, and improvements to crash analytics.
 thumbnail: /blog-resources/v3-5/Hero.png
 date: 6/24/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that starting today, Files v3.5 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
@@ -26,7 +26,6 @@ Additionally, Dual Pane mode now features a more pronounced shadow on the active
     <img src="/blog-resources/v3-5/UpdatedDualPaneDesign.png" alt="Updated design for Dual Pane" />
 </figure>
 
-
 ### View dimensions when hovering over images
 
 When you hover over images, a tooltip will now conveniently show the dimensions. This enhancement greatly improves user experience by providing quick and easy access to size information.
@@ -34,7 +33,6 @@ When you hover over images, a tooltip will now conveniently show the dimensions.
 <figure>
     <img src="/blog-resources/v3-5/ImageSizeTooltip.png" alt="Images tooltip" />
 </figure>
-
 
 ### Open batch files in Notepad directly from the toolbar
 
@@ -44,7 +42,6 @@ Upon selecting a batch (.bat) file, the toolbar will now present an Edit in Note
     <img src="/blog-resources/v3-5/EditInNotepad.png" alt="Edit in notepad toolbar button" />
 </figure>
 
-
 ### Explore network locations on the Home Page
 
 We added a "Network Locations" widget on the home page. This feature is designed to help you navigate and organize network locations with greater efficiency.
@@ -53,35 +50,29 @@ We added a "Network Locations" widget on the home page. This feature is designed
     <img src="/blog-resources/v3-5/NetworkLocations.png" alt="Home page widget for network locations" />
 </figure>
 
-
 ### Added support for closing the left pane in Dual Pane mode
 
 We’ve added the ability to close the left pane in Dual Pane mode, overcoming previous technical limitations that only allowed closing the right pane. This improvements provides a more versatile and user-friendly experience.
-
 
 ### OneDrive sync status indicator
 
 Experience enhanced clarity when you hover over a file in OneDrive locations. The sync icon will now display a tooltip detailing the file’s current sync status, offering a more direct and informative snapshot of your data synchronization.
 
-
 ### View duration for selected video files
 
 When selecting multiple video files, the Details Pane will now display the total duration.
 
-
 ### New localizations added
 
-We’ve expanded our language support to now include Belarusian.  Our localizations are largely maintained by our dedicated community members. If you'd like to get involved, we invite you to join us on Crowdin https://crowdin.com/project/files-app.
+We’ve expanded our language support to now include Belarusian. Our localizations are largely maintained by our dedicated community members. If you'd like to get involved, we invite you to join us on Crowdin https://crowdin.com/project/files-app.
 
-
-### Improvements to crash reporting and metrics 
+### Improvements to crash reporting and metrics
 
 While enhancements in performance and stability typically occur behind the scenes, we often get a lot of questions about our work in this area and we wanted to share some highlights.
 
-- We've adopted Sentry for more robust crash reporting (shoutout to Sentry for their support of open-source projects), and we aim to extend its use to monitor performance metrics, ensuring Files gets faster with each update. 
+- We've adopted Sentry for more robust crash reporting (shoutout to Sentry for their support of open-source projects), and we aim to extend its use to monitor performance metrics, ensuring Files gets faster with each update.
 - Our main challenge with startup speed has been the absence of Native AOT in WinAppSdk. Fortunately, Microsoft is working to address this, and we hope to integrate these advancements later in the year.
 - We recently started a new effort to eliminate unnecessary dependencies and streamline app resources, effectively shrinking the app’s footprint on your device.
-
 
 ## Changes and Improvements
 
@@ -114,7 +105,6 @@ While enhancements in performance and stability typically occur behind the scene
 - Fixed a potential crash when trying to locate the Libraries folder
 - Fixed a potential crash when clicking items in the Quick Access widget
 - Fixed a potential crash from occuring when deleting items
-
 
 ### Conclusion
 

--- a/src/routes/blog/posts/v3-6/+page.md
+++ b/src/routes/blog/posts/v3-6/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.6
 description: Enhance your productivity with Dual Pane's arrangement options, the new "Actions" menu, personalized folder backgrounds, and significant performance improvements.
 thumbnail: /blog-resources/v3-6/Hero.png
 date: 8/6/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that starting today, Files v3.6 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.

--- a/src/routes/blog/posts/v3-6/+page.md
+++ b/src/routes/blog/posts/v3-6/+page.md
@@ -6,7 +6,7 @@ date: 8/6/2024
 author: yaira2
 ---
 
-We're excited to announce that starting today, Files v3.6 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
+We're excited to announce that starting today, Files v3.6 is now available. If you already have Files, there should be a notification on the toolbar to install the update. Otherwise, you can download Files for free from our [download page](/download/). You can also purchase Files on the [Microsoft Store](https://apps.microsoft.com/detail/9nghp3dx8hdx?mode=full) or sponsor us on [GitHub](https://github.com/sponsors/yaira2) to help support the project.
 
 **TL;DR:** The latest update, Files v3.6, introduces support for changing the pane arrangement in Dual Pane mode, a new "Actions" menu, custom background images for folders, improved performance, and more. Continue reading to learn more about these enhancements.
 

--- a/src/routes/blog/posts/v3-7-6/+page.md
+++ b/src/routes/blog/posts/v3-7-6/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.7.6
 description: Discover the latest improvements in Files v3.7.6, including improved toolbar settings, the ability to open more than 10 files simultaneously, and several important fixes.
 thumbnail: /blog-resources/v3-4-1/Hero.png
 date: 9/13/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that Files v3.7.6 is now available! 🎉 Existing users will receive an update notification in the top right corner of the app, while new users can get started for free from our [download page](/download/). Additionally, you can help support the project by purchasing Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsoring us on [GitHub](https://github.com/sponsors/yaira2). Your support is greatly appreciated but entirely optional.

--- a/src/routes/blog/posts/v3-7-7/+page.md
+++ b/src/routes/blog/posts/v3-7-7/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.7.7
 description: Fixed support for QuickLook.
 thumbnail: /blog-resources/v3-4-1/Hero.png
 date: 9/16/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that Files v3.7.7 is now available! 🎉 Existing users will receive an update notification in the top right corner of the app, while new users can get started for free from our [download page](/download/). Additionally, you can help support the project by purchasing Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsoring us on [GitHub](https://github.com/sponsors/yaira2). Your support is greatly appreciated but entirely optional.

--- a/src/routes/blog/posts/v3-7/+page.md
+++ b/src/routes/blog/posts/v3-7/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3.7
 description: Discover the latest features in Files v3.7, including navigation history for back/forward buttons, folder thumbnails in breadcrumb flyouts, and an option to hide the System Tray icon. 
 thumbnail: /blog-resources/v3-7/Hero.png
 date: 9/5/2024
-author: files-community
+author: yaira2
 ---
 
 We're excited to announce that Files v3.7 is now available! 🎉 This update brings a host of new features and improvements designed to enhance your experience. Existing users will receive an update notification in the top right corner of the app, while new users can get started for free from our [download page](/download/). Additionally, you can help support the project by purchasing Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or sponsoring us on [GitHub](https://github.com/sponsors/yaira2). Your support is greatly appreciated but entirely optional.

--- a/src/routes/blog/posts/v3/+page.md
+++ b/src/routes/blog/posts/v3/+page.md
@@ -3,7 +3,7 @@ title: Announcing Files v3
 description: A design refresh, faster startup performance, support for previewing Office documents, & and speed graph for file operations.
 thumbnail: /blog-resources/v3/Hero.jpg
 date: 11/8/2023
-author: files-community
+author: yaira2
 ---
 
 It's just a little over two years since the launch of v2, and the feedback from the community has encouraged us to keep on improving. Our mission with Files is to build the best file manager for Windows, and we're proud to be building it out in the open so everyone can participate and provide feedback. We're keenly aware that we wouldn't have gotten to this point without the support of our dedicated users and the open source community, and we want to extend a thank you to everyone who's been involved with the project until this point.
@@ -18,7 +18,7 @@ We're excited to announce that starting today, v3 is now available. If you alrea
 
 When we set out to update the design, we wanted to ensure users would feel at home with the app they love. We were careful not to move the options and commands users are familiar with, whilst modernizing and refreshing core parts of the UI.
 
-- With v3 being one of the larger releases to date, we decided it was a good time to refresh the logo. After exploring a number of ideas and color combinations, we asked the community to help choose a color. It's probably no surprise, but the community overwhelmingly opted in favor of the familiar yellow color. We also updated the icons for the developer and preview versions of Files (purple & blue) to make it easier to identify the different variants of the app. 
+- With v3 being one of the larger releases to date, we decided it was a good time to refresh the logo. After exploring a number of ideas and color combinations, we asked the community to help choose a color. It's probably no surprise, but the community overwhelmingly opted in favor of the familiar yellow color. We also updated the icons for the developer and preview versions of Files (purple & blue) to make it easier to identify the different variants of the app.
 
 <figure>
     <img src="/blog-resources/v3/NewIcon.jpg" alt="Updated Files Icon for all branches" />
@@ -58,7 +58,6 @@ We're excited to introduce a Command Palette that lets you search and execute co
 ### Keep Files in the background
 
 We added an option to keep Files open in the background when closing the last window. This option is designed to improve the startup performance but can be turned on/off from the advanced settings page. Please be advised the using this option will use system resources even when the app is in the background.
-
 
 ## Changes and Improvements
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8501de6f-fad9-4569-a39f-88a966ebfa42)
Previously, the names of authors were removed from blog posts in favour of the @files-community identity instead, however this sort-of breaks the point of having poster names in the blog anyway - isn't a blog meant to be more personal?
I'd say that they should either be removed from the `<Card />` element (or whatever it's called) or reintroduced.