### PR TITLE
Add rule for using `var` instead of explicit type in code style

### DIFF
--- a/src/routes/docs/contributing/code-style/+page.md
+++ b/src/routes/docs/contributing/code-style/+page.md
@@ -46,6 +46,14 @@ To make the codebase consistent and easy to understand, we require you to follow
 5. Use Hungarian Notation only for OS functions/API calls
 6. Use UPPER_CASE for constant variables
 7. Use predefined primitive types like `int`, `long`, `string` instead of `Int32`, `Int64`, `String`
+8. Use `var` instead of explicitly stating type:
+> ```cs
+> string HelloWorld = "Hello, World!";
+> ```
+> would now be
+> ```cs
+> var HelloWorld = "Hello, World!";
+> ```
 
 ### 3. Code readability and clarity
 


### PR DESCRIPTION
@yaira2 I was wondering what your opinion would be on this in the codebase. If so, let's discuss what might be better for the code style.