### PR TITLE
Fix: Fixed typo

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -75,7 +75,7 @@
 			},
 			"remap-key-bindings": {
 				"title": "Remap key bindings",
-				"description": "Streamline you workflow by creating custom key bindings."
+				"description": "Streamline your workflow by creating custom key bindings."
 			}
 		},
 		"themes": {


### PR DESCRIPTION
Fixing minor typo in the Features section. This is supposed to be "Streamline you***r***" right? 🙂