### PR TITLE
Preserve thumbnail aspect ratio

### DIFF
--- a/src/lib/BlogCard/BlogCard.scss
+++ b/src/lib/BlogCard/BlogCard.scss
@@ -28,6 +28,7 @@
 		inline-size: 100%;
 		block-size: 193.5px;
 		-webkit-user-drag: none;
+		object-fit: cover;
 	}
 
 	footer {


### PR DESCRIPTION
## Description

Blog thumbnails currently do not have their aspect ratios preserved, causing them to look weirdly stretched.

## Motivation and Context

<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->

## Screenshots (if appropriate):

**Before:**
<img alt="A blog card before the change, with weirdly shrunk text" width="300" src="https://github.com/user-attachments/assets/199a1096-9cbb-43fe-ac54-15f7d9cb4cf3">

**After:**
<img alt="A blog card after the change, with text in their correct height" width="300" src="https://github.com/user-attachments/assets/06be66b0-b1f7-48ed-a9de-d6f679d4bf9d">