### PR TITLE
Docs: Separate sidebar and content area scrolling

### DIFF
--- a/src/layout/Footer/Footer.svelte
+++ b/src/layout/Footer/Footer.svelte
@@ -4,6 +4,7 @@
 	import { links } from "$data/links";
 	import { _ } from "svelte-i18n";
 	import { onMount } from "svelte";
+	import { page } from "$app/stores";
 	import Github from "./icons/github.svg?raw";
 	import Discord from "./icons/discord.svg?raw";
 
@@ -34,7 +35,7 @@
 	});
 </script>
 
-{#if !minimal}
+{#if !$page.url.pathname.startsWith("/docs") && !minimal}
 	<PageSection type="footer" id="page-footer">
 		<div class="column">
 			<a class="logo" href="/">

--- a/src/lib/TreeView/TreeView.svelte
+++ b/src/lib/TreeView/TreeView.svelte
@@ -110,7 +110,7 @@
 
 		&.initial {
 			@media screen and (width >= 648px) {
-				block-size: calc(100vh - 58px);
+				block-size: calc(100vh - 120px);
 			}
 		}
 	}

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -214,12 +214,10 @@
 		overflow-x: auto;
 		overflow-y: hidden;
 		width: 100%;
-		white-space: nowrap;
 
 		th,
 		td {
 			padding: 6px 13px;
-			width: 1%;
 		}
 
 		th {

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -213,7 +213,6 @@
 		background-clip: padding-box;
 		overflow-x: auto;
 		overflow-y: hidden;
-		width: 100%;
 
 		th,
 		td {

--- a/src/styles/pages/docs.scss
+++ b/src/styles/pages/docs.scss
@@ -6,6 +6,8 @@
 	background-color: var(--fds-solid-background-base);
 
 	.markdown-body {
+		max-height: calc(100vh - 58px); /* 58px to account for nav bar height */
+		overflow-y: scroll;
 		font-size: 1.6rem;
 		line-height: 2.6rem;
 		max-inline-size: 1000px;

--- a/src/styles/pages/docs.scss
+++ b/src/styles/pages/docs.scss
@@ -7,7 +7,8 @@
 
 	.markdown-body {
 		overflow-y: auto;
-		max-height: calc(100vh - 58px); /* 58px to account for nav bar height */
+		/* 58px to account for nav bar height and 1px to account for border */
+		max-height: calc(100vh - 59px);
 		font-size: 1.6rem;
 		line-height: 2.6rem;
 		max-inline-size: 1000px;

--- a/src/styles/pages/docs.scss
+++ b/src/styles/pages/docs.scss
@@ -6,8 +6,8 @@
 	background-color: var(--fds-solid-background-base);
 
 	.markdown-body {
+		overflow-y: auto;
 		max-height: calc(100vh - 58px); /* 58px to account for nav bar height */
-		overflow-y: scroll;
 		font-size: 1.6rem;
 		line-height: 2.6rem;
 		max-inline-size: 1000px;

--- a/src/styles/pages/docs.scss
+++ b/src/styles/pages/docs.scss
@@ -121,7 +121,7 @@
 }
 
 // Don't add padding to force scroll bar to the right of window when smaller then content area width
-@media screen and (width < 1385px) {
+@media screen and (width < 1335px) {
 	.page {
 		&-inner {
 			padding: 44px 56px;
@@ -130,7 +130,7 @@
 }
 
 // Small device support
-@media screen and (width < 648px) {
+@media screen and (width < 804px) {
 	// Since we don't have a sidebar anymore, vertically stack the elements in the page
 	.docs {
 		flex-direction: column;

--- a/src/styles/pages/docs.scss
+++ b/src/styles/pages/docs.scss
@@ -31,7 +31,7 @@
 	// absolute positioning on the mobile search UI.
 	&-inner {
 		// Forces scroll bar to right side of window, Side bar 308px, left padding 56px, content area 914px
-		padding: 44px calc(100vw - 1328px) 44px 56px;
+		padding: 44px calc(100vw - 1278px) 44px 56px;
 		view-transition-name: docs-content;
 	}
 

--- a/src/styles/pages/docs.scss
+++ b/src/styles/pages/docs.scss
@@ -11,7 +11,6 @@
 		max-height: calc(100vh - 59px);
 		font-size: 1.6rem;
 		line-height: 2.6rem;
-		max-inline-size: 1000px;
 	}
 }
 
@@ -31,7 +30,8 @@
 	// This is mainly here because I didn't want to use
 	// absolute positioning on the mobile search UI.
 	&-inner {
-		padding: 44px 56px;
+		// Forces scroll bar to right side of window, Side bar 308px, left padding 56px, content area 914px
+		padding: 44px calc(100vw - 1328px) 44px 56px;
 		view-transition-name: docs-content;
 	}
 
@@ -120,6 +120,15 @@
 	}
 }
 
+// Don't add padding to force scroll bar to the right of window when smaller then content area width
+@media screen and (width < 1385px) {
+	.page {
+		&-inner {
+			padding: 44px 56px;
+		}
+	}
+}
+
 // Small device support
 @media screen and (width < 648px) {
 	// Since we don't have a sidebar anymore, vertically stack the elements in the page
@@ -127,6 +136,11 @@
 		flex-direction: column;
 		margin-block-start: 2px;
 		border-block-start: 1px solid var(--fds-card-stroke-default);
+
+		// Fixes double scroll bar
+		.markdown-body {
+			max-height: calc(100vh - 128px);
+		}
 	}
 
 	// Hide the sidebar


### PR DESCRIPTION
## Description

- Fixed sidebar height to account for the search bar
- Removed footer on docs page
   - Tested the minimal parameter still removes the footer on other pages and that the footer is visible on all other pages than docs
- Made content area a separate scroll area
   - Scrollbar doesn't show if the nothing to scroll
   - Has the benefit of also warping text rather than cutting it off on smaller window widths. This should increase readability with different screen widths.
- Made tables wrap text to avoid having to scroll left and right

<img height="512" alt="image" src="https://github.com/user-attachments/assets/2b3aefe1-ba4b-4578-bd15-07afa34088e7" /> <img height="512" alt="image" src="https://github.com/user-attachments/assets/53682033-645d-4b97-bd5d-1919d6abc618" /> <img height="512" alt="image" src="https://github.com/user-attachments/assets/921000bb-ed7d-447d-848f-658ce3c86b22" />



Note repo says to use lint https://github.com/files-community/Website?tab=readme-ov-file#linting to make changes consistent but many files haven't had this done so I haven't included it in this PR.


## Motivation and Context

<!-- Why are those changes required? If it fixes an open issue, please link the issue using the syntax "Closes #1234" or "Fixes #1234" -->

## Screenshots (if appropriate):

<!-- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
