### PR TITLE
Fix typo on tabs feature page

### DIFF
--- a/src/routes/docs/features/tabs/+page.md
+++ b/src/routes/docs/features/tabs/+page.md
@@ -14,7 +14,7 @@ There are a couple of ways to open folders in a new tab. If your mouse has a mid
 
 ## Tab tear off
 
-In addition to reordering tabs, you can tear off a tab to create a new window. You can also move tags between windows with drag & drop.
+In addition to reordering tabs, you can tear off a tab to create a new window. You can also move tabs between windows with drag & drop.
 
 ## Drag files between tabs
 


### PR DESCRIPTION
## Description
Fixes a typo on the **Multitask with tabs** page where it says "tags" rather than "tabs". 

## Screenshot
The typo is highlighted below: 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fe882db5-5032-40af-9cc6-bb5e3f74eb7f" />

